### PR TITLE
feat: add universal manipulator library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,102 @@
-# cesium-universal-manipulator
+# Cesium Universal Manipulator
+
+A reusable translate / rotate / scale gizmo for CesiumJS 1.133 scenes. The manipulator renders high-visibility handles, supports axis/plane constraints, configurable snapping, multi-selection pivots, and HUD feedback. The code is framework-agnostic and works directly with the CesiumJS Viewer.
+
+## Quick start
+
+```bash
+# clone the repository
+npm install
+npm run build
+```
+
+Open `examples/index.html` from a static server (for example `npx serve`) to play with the demo scene. The example loads Cesium from the public CDN and imports the library straight from `src/` for easy iteration.
+
+## Usage
+
+```js
+import { UniversalManipulator } from 'cesium-universal-manipulator';
+
+const manipulator = new UniversalManipulator({
+  Cesium,
+  viewer,
+  target: entityOrArray,
+  mode: 'translate',
+  orientation: 'global',
+  pivot: 'origin',
+  snap: {
+    translate: 1.0,           // meters
+    rotate: Cesium.Math.toRadians(5),
+    scale: 0.1,
+  },
+  size: {
+    screenRadius: 110,
+    minScale: 0.2,
+    maxScale: 2.5,
+  },
+});
+```
+
+Call `manipulator.destroy()` to clean up when finished.
+
+## API
+
+### `new UniversalManipulator(options)`
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `Cesium` | `typeof Cesium` | required | Cesium namespace (e.g. the global `Cesium`). |
+| `viewer` | `Cesium.Viewer` | required | Viewer hosting the gizmo. |
+| `target` | `Transformable | Transformable[]` | `null` | Initial selection target(s). |
+| `mode` | `'translate' | 'rotate' | 'scale'` | `'translate'` | Active manipulation mode. |
+| `orientation` | `'global' | 'local' | 'view' | 'enu' | 'normal' | 'gimbal'` | `'global'` | Handle frame orientation. |
+| `pivot` | `'origin' | 'median' | 'cursor' | 'individual'` | `'origin'` | Pivot policy for transforms. |
+| `snap` | `{ translate?: number, rotate?: number, scale?: number }` | `{}` | Snapping step configuration. |
+| `size` | `{ screenRadius?: number, minScale?: number, maxScale?: number }` | `{}` | Screen-size behaviour. |
+| `hudContainer` | `HTMLElement` | `viewer.container` | DOM container for the delta HUD. |
+
+Targets can be:
+
+- Plain objects with a `matrix` or `modelMatrix` property (4×4 column-major array).
+- Objects exposing `getWorldMatrix()` / `setMatrix(matrix)`.
+- Wrappers around `Cesium.Entity` instances (the built-in adapter updates `position`, `orientation`, and `model.scale`).
+
+### Instance methods
+
+- `setTarget(target | target[])` — Update the current selection (single object or array).
+- `setMode(mode)` — Switch between translate/rotate/scale. Respects `enable()` toggles.
+- `setOrientation(orientation)` — Change orientation frame (global, local, view, ENU, normal, gimbal).
+- `setPivot(pivot)` — Choose pivot behaviour (origin, median, cursor, individual).
+- `enable({ translate?, rotate?, scale? })` — Enable/disable specific modes. Disabled modes throw if selected; the manipulator falls back to the first enabled mode.
+- `setSnap(stepConfig)` — Update snapping step sizes (translate in meters, rotate in radians, scale factor).
+- `setSize(screenRadius, minScale, maxScale)` — Control screen-space gizmo size behaviour.
+- `destroy()` — Dispose the gizmo, controller, and HUD.
+
+### Properties
+
+- `show` (getter/setter) — Toggle overall gizmo visibility without removing event handlers.
+
+## Architecture overview
+
+The library is modular and each component can be used independently:
+
+- `GizmoPrimitive` — Renders handles as Cesium entities, manages colours, highlights, and size.
+- `GizmoPicker` — Wraps `scene.pick`/`drillPick` to resolve handle metadata.
+- `FrameBuilder` — Produces orientation frames (global, local, view, ENU, normal, gimbal).
+- `PivotResolver` — Computes pivot positions for single and multi-selection modes.
+- `TransformSolver` — Pure math helpers that map drag rays to translation/rotation/scale deltas.
+- `Snapper` — Applies translate/rotate/scale snapping with modifier awareness.
+- `ManipulatorController` — Event/state machine hooking into Cesium pointer events, applying transforms, updating the gizmo, and driving the HUD.
+- `HudOverlay` — Lightweight DOM HUD for live delta readouts (auto-disabled in non-DOM environments).
+
+## Testing
+
+A lightweight test harness covers the math and transform solvers:
+
+```bash
+npm test
+```
+
+## License
+
+MIT

--- a/dist/FrameBuilder.js
+++ b/dist/FrameBuilder.js
@@ -1,0 +1,113 @@
+import {
+  IDENTITY_QUATERNION,
+  UNIT_X,
+  UNIT_Y,
+  UNIT_Z,
+  buildLookAt,
+  decomposeTransform,
+  ensureOrthogonalAxes,
+  normalize,
+  quaternionToMatrix,
+  ZERO_VECTOR,
+} from './math.js';
+
+function extractMatrix(target) {
+  if (!target) {
+    return null;
+  }
+  if (target.matrix) {
+    return target.matrix;
+  }
+  if (target.modelMatrix) {
+    return target.modelMatrix;
+  }
+  if (typeof target.getWorldMatrix === 'function') {
+    return target.getWorldMatrix();
+  }
+  if (target.entity && target.entity.computeModelMatrix) {
+    return target.entity.computeModelMatrix(Date.now());
+  }
+  return null;
+}
+
+function matrixAxes(rotationMatrix) {
+  return {
+    x: { x: rotationMatrix[0], y: rotationMatrix[3], z: rotationMatrix[6] },
+    y: { x: rotationMatrix[1], y: rotationMatrix[4], z: rotationMatrix[7] },
+    z: { x: rotationMatrix[2], y: rotationMatrix[5], z: rotationMatrix[8] },
+  };
+}
+
+function fromRotation(quaternion) {
+  const matrix = quaternionToMatrix(quaternion);
+  return matrixAxes(matrix);
+}
+
+function computeENU(position, cesium, ellipsoid) {
+  if (cesium?.Transforms?.eastNorthUpToFixedFrame) {
+    const matrix = cesium.Transforms.eastNorthUpToFixedFrame(position, ellipsoid);
+    return {
+      origin: position,
+      axes: {
+        x: { x: matrix[0], y: matrix[4], z: matrix[8] },
+        y: { x: matrix[1], y: matrix[5], z: matrix[9] },
+        z: { x: matrix[2], y: matrix[6], z: matrix[10] },
+      },
+    };
+  }
+  return { origin: position, axes: { x: UNIT_X, y: UNIT_Y, z: UNIT_Z } };
+}
+
+export class FrameBuilder {
+  constructor(options = {}) {
+    this.cesium = options.cesium;
+    this.ellipsoid = options.ellipsoid ?? options.cesium?.Ellipsoid?.WGS84;
+  }
+
+  buildFrame({ target, orientation = 'global', camera, normal, gimbalYaw = 0, gimbalPitch = 0 }) {
+    const matrix = extractMatrix(target);
+    let origin = ZERO_VECTOR;
+    let rotation = IDENTITY_QUATERNION;
+    if (matrix) {
+      const decomposed = decomposeTransform(matrix);
+      origin = decomposed.translation;
+      rotation = decomposed.rotation;
+    }
+
+    switch (orientation) {
+      case 'global':
+        return { origin, axes: { x: UNIT_X, y: UNIT_Y, z: UNIT_Z } };
+      case 'local': {
+        const axes = ensureOrthogonalAxes(fromRotation(rotation));
+        return { origin, axes };
+      }
+      case 'view': {
+        if (!camera) {
+          return { origin, axes: { x: UNIT_X, y: UNIT_Y, z: UNIT_Z } };
+        }
+        const axes = {
+          x: camera.right ?? UNIT_X,
+          y: camera.up ?? UNIT_Y,
+          z: camera.direction ? normalize(camera.direction) : UNIT_Z,
+        };
+        return { origin, axes: ensureOrthogonalAxes(axes) };
+      }
+      case 'enu': {
+        return computeENU(origin, this.cesium, this.ellipsoid);
+      }
+      case 'normal': {
+        const referenceNormal = normal ?? UNIT_Z;
+        const axes = buildLookAt(referenceNormal, UNIT_Z);
+        return { origin, axes: ensureOrthogonalAxes(axes) };
+      }
+      case 'gimbal': {
+        const yawAxis = { x: Math.cos(gimbalYaw), y: 0, z: Math.sin(gimbalYaw) };
+        const pitchAxis = { x: 0, y: Math.cos(gimbalPitch), z: Math.sin(gimbalPitch) };
+        const axes = ensureOrthogonalAxes({ x: yawAxis, y: pitchAxis, z: UNIT_Z });
+        return { origin, axes };
+      }
+      default:
+        return { origin, axes: { x: UNIT_X, y: UNIT_Y, z: UNIT_Z } };
+    }
+  }
+}

--- a/dist/GizmoPicker.js
+++ b/dist/GizmoPicker.js
@@ -1,0 +1,46 @@
+export class GizmoPicker {
+  constructor(scene, gizmo) {
+    this.scene = scene;
+    this.gizmo = gizmo;
+  }
+
+  pick(position) {
+    if (!this.scene) return null;
+    const picked = this.scene.pick(position);
+    if (!picked) return null;
+    const entity = picked.id ?? picked;
+    const id = typeof entity === 'string' ? entity : entity.id;
+    if (!id) return null;
+    const handle = this.gizmo.handles.get(id);
+    if (!handle) return null;
+    return {
+      id,
+      mode: handle.mode,
+      axis: handle.axis,
+      plane: handle.plane,
+      type: handle.type,
+      entity,
+    };
+  }
+
+  drillPick(position) {
+    const picks = this.scene.drillPick(position, 5);
+    for (const picked of picks) {
+      const entity = picked.id ?? picked;
+      const id = typeof entity === 'string' ? entity : entity.id;
+      if (!id) continue;
+      const handle = this.gizmo.handles.get(id);
+      if (handle) {
+        return {
+          id,
+          mode: handle.mode,
+          axis: handle.axis,
+          plane: handle.plane,
+          type: handle.type,
+          entity,
+        };
+      }
+    }
+    return null;
+  }
+}

--- a/dist/GizmoPrimitive.js
+++ b/dist/GizmoPrimitive.js
@@ -1,0 +1,433 @@
+import { AXIS_COLORS, HANDLE_TYPES, MODE_HANDLES } from './constants.js';
+
+function colorFromArray(Cesium, array) {
+  return new Cesium.Color(array[0], array[1], array[2], array[3]);
+}
+
+function toCartesian3(Cesium, vector) {
+  return new Cesium.Cartesian3(vector.x, vector.y, vector.z);
+}
+
+function computeWorldScale(Cesium, scene, camera, origin, size) {
+  const distance = Cesium.Cartesian3.distance(camera.position, origin);
+  const canvas = scene.canvas;
+  const frustum = camera.frustum;
+  const fov = frustum.fovy ?? frustum.fov ?? Math.PI / 3;
+  const metersPerPixel = (2 * distance * Math.tan(fov * 0.5)) / canvas.height;
+  let scale = metersPerPixel * size.screenRadius;
+  const minWorld = size.minScale * distance;
+  const maxWorld = size.maxScale * distance;
+  scale = Cesium.Math.clamp(scale, minWorld, maxWorld);
+  return scale;
+}
+
+function unitCirclePoints(Cesium, axesA, axesB, origin, radius, segments) {
+  const positions = [];
+  for (let i = 0; i <= segments; i++) {
+    const t = (i / segments) * Math.PI * 2;
+    const local = {
+      x: Math.cos(t) * radius,
+      y: Math.sin(t) * radius,
+      z: 0,
+    };
+    const axisOffset = Cesium.Cartesian3.add(
+      Cesium.Cartesian3.multiplyByScalar(axesA, local.x, new Cesium.Cartesian3()),
+      Cesium.Cartesian3.multiplyByScalar(axesB, local.y, new Cesium.Cartesian3()),
+      new Cesium.Cartesian3()
+    );
+    positions.push(Cesium.Cartesian3.add(origin, axisOffset, axisOffset));
+  }
+  return positions;
+}
+
+function planeSquare(Cesium, origin, axisA, axisB, size) {
+  const half = size * 0.5;
+  const corners = [
+    { x: 0, y: 0, z: 0 },
+    { x: half, y: 0, z: 0 },
+    { x: half, y: half, z: 0 },
+    { x: 0, y: half, z: 0 },
+  ];
+  return corners.map((corner) =>
+    Cesium.Cartesian3.add(
+      origin,
+      Cesium.Cartesian3.add(
+        Cesium.Cartesian3.multiplyByScalar(axisA, corner.x * 2, new Cesium.Cartesian3()),
+        Cesium.Cartesian3.multiplyByScalar(axisB, corner.y * 2, new Cesium.Cartesian3()),
+        new Cesium.Cartesian3()
+      ),
+      new Cesium.Cartesian3()
+    )
+  );
+}
+
+export class GizmoPrimitive {
+  constructor({ Cesium, viewer, colors = {}, size = {} }) {
+    if (!Cesium) {
+      throw new Error('Cesium namespace is required to create GizmoPrimitive.');
+    }
+    this.Cesium = Cesium;
+    this.viewer = viewer;
+    this.scene = viewer.scene;
+    this.colors = {
+      x: { ...AXIS_COLORS.x, ...colors.x },
+      y: { ...AXIS_COLORS.y, ...colors.y },
+      z: { ...AXIS_COLORS.z, ...colors.z },
+      view: { ...AXIS_COLORS.view, ...colors.view },
+    };
+    this.size = { ...DEFAULT_SIZE, ...size };
+    this.handles = new Map();
+    this.entities = [];
+    this.show = true;
+    this.activeHandle = null;
+    this.hoverHandle = null;
+    this._createHandles();
+  }
+
+  _createHandles() {
+    this._createTranslationAxes();
+    this._createTranslationPlanes();
+    this._createScaleHandles();
+    this._createRotationRings();
+    this._createUniformScale();
+    this.mode = 'translate';
+    this._applyVisibility();
+  }
+
+  _createEntity(handleId, options) {
+    const entity = this.viewer.entities.add({
+      id: handleId,
+      show: true,
+      ...options,
+    });
+    this.entities.push(entity);
+    return entity;
+  }
+
+  _createTranslationAxes() {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const color = colorFromArray(Cesium, this.colors[axis].inactive);
+      const entity = this._createEntity(`translate-${axis}`, {
+        polyline: {
+          positions: [Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO],
+          width: 4,
+          material: color,
+          followSurface: false,
+          clampToGround: false,
+          classificationType: Cesium.ClassificationType.NONE,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+        point: {
+          pixelSize: 16,
+          color,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+      entity.properties = new Cesium.PropertyBag({
+        axis,
+        mode: 'translate',
+        type: HANDLE_TYPES.TRANSLATE_AXIS,
+      });
+      this.handles.set(`translate-${axis}`, { entity, axis, mode: 'translate', type: HANDLE_TYPES.TRANSLATE_AXIS });
+    });
+  }
+
+  _createTranslationPlanes() {
+    const Cesium = this.Cesium;
+    [['xy', 'z'], ['yz', 'x'], ['xz', 'y']].forEach(([plane, axis]) => {
+      const color = colorFromArray(Cesium, this.colors[axis].inactive);
+      const entity = this._createEntity(`translate-${plane}`, {
+        polygon: {
+          hierarchy: new Cesium.PolygonHierarchy([Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO]),
+          material: color.withAlpha(0.2),
+          classificationType: Cesium.ClassificationType.NONE,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+        polyline: {
+          positions: [Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO],
+          width: 2,
+          material: color,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+      entity.properties = new Cesium.PropertyBag({
+        mode: 'translate',
+        plane,
+        axis,
+        type: HANDLE_TYPES.TRANSLATE_PLANE,
+      });
+      this.handles.set(`translate-${plane}`, { entity, plane, mode: 'translate', type: HANDLE_TYPES.TRANSLATE_PLANE });
+    });
+  }
+
+  _createScaleHandles() {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const color = colorFromArray(Cesium, this.colors[axis].inactive);
+      const entity = this._createEntity(`scale-${axis}`, {
+        polyline: {
+          positions: [Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO],
+          width: 3,
+          material: color,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+        billboard: {
+          image: this._createSquareTexture(color),
+          width: 22,
+          height: 22,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+      entity.properties = new Cesium.PropertyBag({
+        axis,
+        mode: 'scale',
+        type: HANDLE_TYPES.SCALE_AXIS,
+      });
+      this.handles.set(`scale-${axis}`, { entity, axis, mode: 'scale', type: HANDLE_TYPES.SCALE_AXIS });
+    });
+  }
+
+  _createRotationRings() {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const color = colorFromArray(Cesium, this.colors[axis].inactive);
+      const entity = this._createEntity(`rotate-${axis}`, {
+        polyline: {
+          positions: new Array(65).fill(Cesium.Cartesian3.ZERO),
+          width: 2,
+          material: color,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+      entity.properties = new Cesium.PropertyBag({
+        axis,
+        mode: 'rotate',
+        type: HANDLE_TYPES.ROTATE_AXIS,
+      });
+      this.handles.set(`rotate-${axis}`, { entity, axis, mode: 'rotate', type: HANDLE_TYPES.ROTATE_AXIS });
+    });
+
+    const viewColor = colorFromArray(Cesium, this.colors.view.inactive);
+    const viewEntity = this._createEntity('rotate-view', {
+      polyline: {
+        positions: new Array(65).fill(Cesium.Cartesian3.ZERO),
+        width: 2,
+        material: viewColor,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+      },
+    });
+    viewEntity.properties = new Cesium.PropertyBag({
+      mode: 'rotate',
+      type: HANDLE_TYPES.ROTATE_VIEW,
+    });
+    this.handles.set('rotate-view', { entity: viewEntity, mode: 'rotate', type: HANDLE_TYPES.ROTATE_VIEW });
+  }
+
+  _createUniformScale() {
+    const Cesium = this.Cesium;
+    const color = colorFromArray(Cesium, this.colors.view.inactive);
+    const entity = this._createEntity('scale-uniform', {
+      point: {
+        pixelSize: 18,
+        color,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+      },
+    });
+    entity.properties = new Cesium.PropertyBag({
+      mode: 'scale',
+      type: HANDLE_TYPES.SCALE_UNIFORM,
+    });
+    this.handles.set('scale-uniform', { entity, mode: 'scale', type: HANDLE_TYPES.SCALE_UNIFORM });
+  }
+
+  _createSquareTexture(color) {
+    const size = 32;
+    if (typeof document === 'undefined') {
+      return color.toCssColorString();
+    }
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const context = canvas.getContext('2d');
+    context.fillStyle = color.toCssColorString();
+    context.fillRect(0, 0, size, size);
+    context.clearRect(6, 6, size - 12, size - 12);
+    context.lineWidth = 2;
+    context.strokeStyle = color.toCssColorString();
+    context.strokeRect(4, 4, size - 8, size - 8);
+    return canvas;
+  }
+
+  setShow(show) {
+    this.show = show;
+    this._applyVisibility();
+  }
+
+  setMode(mode) {
+    this.mode = mode;
+    this._applyVisibility();
+  }
+
+  _applyVisibility() {
+    this.entities.forEach((entity) => {
+      const handle = this.handles.get(entity.id);
+      const isModeMatch = handle?.mode === this.mode;
+      entity.show = Boolean(this.show && isModeMatch);
+    });
+  }
+
+  update(frame, camera, options = {}) {
+    if (!frame) return;
+    const Cesium = this.Cesium;
+    const origin = new Cesium.Cartesian3(frame.origin.x, frame.origin.y, frame.origin.z);
+    const axes = {
+      x: toCartesian3(Cesium, frame.axes.x),
+      y: toCartesian3(Cesium, frame.axes.y),
+      z: toCartesian3(Cesium, frame.axes.z),
+    };
+    const scaleSize = computeWorldScale(Cesium, this.scene, camera, origin, {
+      ...this.size,
+      ...options,
+    });
+
+    this._updateTranslationAxes(origin, axes, scaleSize);
+    this._updateTranslationPlanes(origin, axes, scaleSize * 0.6);
+    this._updateScaleHandles(origin, axes, scaleSize * 0.8);
+    this._updateRotationRings(origin, axes, scaleSize);
+    this._updateUniformScale(origin);
+  }
+
+  _updateTranslationAxes(origin, axes, length) {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const handle = this.handles.get(`translate-${axis}`);
+      if (!handle) return;
+      const entity = handle.entity;
+      const axisVector = axes[axis];
+      const end = Cesium.Cartesian3.add(
+        origin,
+        Cesium.Cartesian3.multiplyByScalar(axisVector, length, new Cesium.Cartesian3()),
+        new Cesium.Cartesian3()
+      );
+      entity.polyline.positions = [origin, end];
+      entity.point.position = end;
+    });
+  }
+
+  _updateTranslationPlanes(origin, axes, size) {
+    const Cesium = this.Cesium;
+    const combos = {
+      xy: ['x', 'y'],
+      yz: ['y', 'z'],
+      xz: ['x', 'z'],
+    };
+    Object.entries(combos).forEach(([plane, [axisA, axisB]]) => {
+      const handle = this.handles.get(`translate-${plane}`);
+      if (!handle) return;
+      const entity = handle.entity;
+      const a = axes[axisA];
+      const b = axes[axisB];
+      const corners = planeSquare(Cesium, origin, a, b, size);
+      entity.polygon.hierarchy = new Cesium.PolygonHierarchy(corners);
+      entity.polyline.positions = [...corners, corners[0]];
+    });
+  }
+
+  _updateScaleHandles(origin, axes, length) {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const handle = this.handles.get(`scale-${axis}`);
+      if (!handle) return;
+      const entity = handle.entity;
+      const axisVector = axes[axis];
+      const end = Cesium.Cartesian3.add(
+        origin,
+        Cesium.Cartesian3.multiplyByScalar(axisVector, length, new Cesium.Cartesian3()),
+        new Cesium.Cartesian3()
+      );
+      entity.polyline.positions = [origin, end];
+      entity.billboard.position = end;
+    });
+  }
+
+  _updateRotationRings(origin, axes, radius) {
+    const Cesium = this.Cesium;
+    const segments = 64;
+    const combos = {
+      x: ['y', 'z'],
+      y: ['x', 'z'],
+      z: ['x', 'y'],
+    };
+    Object.entries(combos).forEach(([axis, [a, b]]) => {
+      const handle = this.handles.get(`rotate-${axis}`);
+      if (!handle) return;
+      const positions = unitCirclePoints(Cesium, axes[a], axes[b], origin, radius, segments);
+      handle.entity.polyline.positions = positions;
+    });
+    const viewHandle = this.handles.get('rotate-view');
+    if (viewHandle) {
+      const positions = unitCirclePoints(
+        Cesium,
+        axes.x,
+        axes.y,
+        origin,
+        radius * 1.05,
+        segments
+      );
+      viewHandle.entity.polyline.positions = positions;
+    }
+  }
+
+  _updateUniformScale(origin) {
+    const handle = this.handles.get('scale-uniform');
+    if (!handle) return;
+    handle.entity.point.position = origin;
+  }
+
+  setHover(handleId) {
+    this.hoverHandle = handleId;
+    this._refreshColors();
+  }
+
+  setActive(handleId) {
+    this.activeHandle = handleId;
+    this._refreshColors();
+  }
+
+  _refreshColors() {
+    const Cesium = this.Cesium;
+    this.handles.forEach((handle, id) => {
+      const entity = handle.entity;
+      const axis = handle.axis ?? 'view';
+      const palette = this.colors[axis] ?? this.colors.view;
+      let colorArray = palette.inactive;
+      if (this.activeHandle === id) {
+        colorArray = palette.active ?? palette.hover ?? palette.inactive;
+      } else if (this.hoverHandle === id) {
+        colorArray = palette.hover ?? palette.inactive;
+      }
+      const color = colorFromArray(Cesium, colorArray);
+      if (entity.polyline) {
+        entity.polyline.material = color;
+      }
+      if (entity.point) {
+        entity.point.color = color;
+      }
+      if (entity.billboard) {
+        entity.billboard.color = color;
+      }
+      if (entity.polygon) {
+        entity.polygon.material = color.withAlpha(0.2);
+      }
+    });
+  }
+
+  destroy() {
+    this.entities.forEach((entity) => {
+      this.viewer.entities.remove(entity);
+    });
+    this.entities.length = 0;
+    this.handles.clear();
+  }
+}

--- a/dist/HudOverlay.js
+++ b/dist/HudOverlay.js
@@ -1,0 +1,61 @@
+export class HudOverlay {
+  constructor({ container = null } = {}) {
+    if (typeof document === 'undefined') {
+      this.enabled = false;
+      return;
+    }
+    this.enabled = true;
+    this.container = container ?? document.body;
+    this.root = document.createElement('div');
+    this.root.className = 'universal-manipulator-hud';
+    Object.assign(this.root.style, {
+      position: 'absolute',
+      top: '12px',
+      right: '12px',
+      padding: '8px 12px',
+      borderRadius: '6px',
+      background: 'rgba(0,0,0,0.6)',
+      color: '#fff',
+      fontFamily: 'sans-serif',
+      fontSize: '12px',
+      pointerEvents: 'none',
+      minWidth: '160px',
+      display: 'none',
+      zIndex: 1000,
+    });
+    this.titleEl = document.createElement('div');
+    this.valueEl = document.createElement('div');
+    this.root.appendChild(this.titleEl);
+    this.root.appendChild(this.valueEl);
+    this.container.appendChild(this.root);
+  }
+
+  setVisible(visible) {
+    if (!this.enabled) return;
+    this.root.style.display = visible ? 'block' : 'none';
+  }
+
+  update({ mode, axis, plane, values }) {
+    if (!this.enabled) return;
+    this.titleEl.textContent = `${mode.toUpperCase()} ${axis ?? plane ?? ''}`.trim();
+    if (!values) {
+      this.valueEl.textContent = '';
+      return;
+    }
+    if (typeof values === 'number') {
+      this.valueEl.textContent = values.toFixed(3);
+      return;
+    }
+    if (Array.isArray(values)) {
+      this.valueEl.textContent = values.map((v) => v.toFixed(3)).join(' , ');
+      return;
+    }
+    const parts = Object.entries(values).map(([key, value]) => `${key}: ${Number(value).toFixed(3)}`);
+    this.valueEl.textContent = parts.join('  ');
+  }
+
+  destroy() {
+    if (!this.enabled) return;
+    this.root.remove();
+  }
+}

--- a/dist/ManipulatorController.js
+++ b/dist/ManipulatorController.js
@@ -1,0 +1,458 @@
+import {
+  beginAxisTranslation,
+  updateAxisTranslation,
+  beginPlaneTranslation,
+  updatePlaneTranslation,
+  beginAxisRotation,
+  updateAxisRotation,
+  beginViewRotation,
+  beginAxisScale,
+  updateAxisScale,
+  beginUniformScale,
+  updateUniformScale,
+} from './TransformSolver.js';
+import { Snapper } from './Snapper.js';
+import { PivotResolver } from './PivotResolver.js';
+import { FrameBuilder } from './FrameBuilder.js';
+import {
+  add,
+  composeTransform,
+  decomposeTransform,
+  projectOnVector,
+  rotateVectorByQuaternion,
+  scale as scaleVector,
+  subtract,
+  ZERO_VECTOR,
+  quaternionMultiply,
+} from './math.js';
+import { HudOverlay } from './HudOverlay.js';
+
+function cartesianToVector(cart) {
+  if (!cart) return ZERO_VECTOR;
+  return { x: cart.x, y: cart.y, z: cart.z };
+}
+
+function rayToSimple(ray) {
+  return {
+    origin: cartesianToVector(ray.origin),
+    direction: cartesianToVector(ray.direction),
+  };
+}
+
+function cloneMatrix(matrix) {
+  return matrix.slice();
+}
+
+function getTargetMatrix(target, Cesium) {
+  if (!target) return null;
+  if (target.matrix) {
+    return target.matrix.slice();
+  }
+  if (target.modelMatrix) {
+    return target.modelMatrix.slice();
+  }
+  if (typeof target.getWorldMatrix === 'function') {
+    return cloneMatrix(target.getWorldMatrix());
+  }
+  if (target.entity && typeof target.entity.computeModelMatrix === 'function') {
+    const time = Cesium?.JulianDate?.now ? Cesium.JulianDate.now() : undefined;
+    return cloneMatrix(target.entity.computeModelMatrix(time));
+  }
+  return null;
+}
+
+function setTargetMatrix(target, matrix, Cesium) {
+  if (target.matrix) {
+    target.matrix = matrix.slice();
+    return;
+  }
+  if (target.modelMatrix) {
+    target.modelMatrix = matrix.slice();
+    return;
+  }
+  if (typeof target.setMatrix === 'function') {
+    target.setMatrix(matrix);
+    return;
+  }
+  if (target.entity) {
+    const translation = { x: matrix[3], y: matrix[7], z: matrix[11] };
+    const rotationMatrix = [
+      matrix[0], matrix[1], matrix[2],
+      matrix[4], matrix[5], matrix[6],
+      matrix[8], matrix[9], matrix[10],
+    ];
+    const scale = {
+      x: Math.hypot(matrix[0], matrix[4], matrix[8]),
+      y: Math.hypot(matrix[1], matrix[5], matrix[9]),
+      z: Math.hypot(matrix[2], matrix[6], matrix[10]),
+    };
+    if (Cesium && target.entity.position) {
+      target.entity.position = new Cesium.ConstantPositionProperty(
+        new Cesium.Cartesian3(translation.x, translation.y, translation.z)
+      );
+    }
+    if (Cesium && target.entity.orientation) {
+      const quaternion = Cesium.Quaternion.fromRotationMatrix(
+        Cesium.Matrix3.fromArray(rotationMatrix)
+      );
+      target.entity.orientation = new Cesium.ConstantProperty(quaternion);
+    }
+    if (target.entity.model) {
+      target.entity.model.scale = (scale.x + scale.y + scale.z) / 3;
+    }
+  }
+}
+
+export class ManipulatorController {
+  constructor({ Cesium, viewer, gizmo, picker, frameBuilder, snapper, pivotResolver, hud }) {
+    this.Cesium = Cesium;
+    this.viewer = viewer;
+    this.scene = viewer.scene;
+    this.gizmo = gizmo;
+    this.picker = picker;
+    this.frameBuilder = frameBuilder ?? new FrameBuilder({ Cesium });
+    this.snapper = snapper ?? new Snapper();
+    this.pivotResolver = pivotResolver ?? new PivotResolver();
+    this.hud = hud ?? new HudOverlay({ container: viewer.container });
+    this.mode = 'translate';
+    this.orientation = 'global';
+    this.targets = [];
+    this.state = 'idle';
+    this.currentHandle = null;
+    this.dragSession = null;
+    this.frame = null;
+    this.pivotData = null;
+    this.clock = viewer.clock;
+    this._keyState = { ctrlKey: false, shiftKey: false, altKey: false };
+    this._registerKeyEvents();
+    this._createHandler();
+  }
+
+  _registerKeyEvents() {
+    if (typeof document === 'undefined') return;
+    this._keyDownListener = (event) => {
+      this._keyState = {
+        ctrlKey: event.ctrlKey || event.metaKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+      };
+    };
+    this._keyUpListener = (event) => {
+      this._keyState = {
+        ctrlKey: event.ctrlKey || event.metaKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+      };
+    };
+    document.addEventListener('keydown', this._keyDownListener);
+    document.addEventListener('keyup', this._keyUpListener);
+  }
+
+  _createHandler() {
+    const Cesium = this.Cesium;
+    this.handler = new Cesium.ScreenSpaceEventHandler(this.scene.canvas);
+    this.handler.setInputAction((movement) => {
+      this._onPointerMove(movement.endPosition ?? movement.position);
+    }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+    this.handler.setInputAction((movement) => {
+      this._onPointerDown(movement.position);
+    }, Cesium.ScreenSpaceEventType.LEFT_DOWN);
+    this.handler.setInputAction((movement) => {
+      this._onPointerUp(movement.position);
+    }, Cesium.ScreenSpaceEventType.LEFT_UP);
+    this.handler.setInputAction(() => {
+      this._cancelDrag();
+    }, Cesium.ScreenSpaceEventType.RIGHT_DOWN);
+  }
+
+  setMode(mode) {
+    this.mode = mode;
+    this.gizmo.setMode(mode);
+  }
+
+  setOrientation(orientation) {
+    this.orientation = orientation;
+    this._updateFrame();
+  }
+
+  setPivot(pivot) {
+    this.pivotResolver.setMode(pivot);
+    this._updateFrame();
+  }
+
+  setTargets(targets) {
+    this.targets = Array.isArray(targets) ? targets : targets ? [targets] : [];
+    this._updateFrame();
+  }
+
+  setSnap(config) {
+    this.snapper.setConfig(config);
+  }
+
+  enableHud(show) {
+    this.hud.setVisible(show);
+  }
+
+  _updateFrame() {
+    if (!this.targets.length) return;
+    const primary = this.targets[0];
+    this.frame = this.frameBuilder.buildFrame({
+      target: primary,
+      orientation: this.orientation,
+      camera: this.scene.camera,
+    });
+    this.gizmo.update(this.frame, this.scene.camera);
+  }
+
+  _onPointerMove(position) {
+    if (!position) return;
+    if (this.state === 'dragging') {
+      this._updateDrag(position);
+      return;
+    }
+    const handle = this.picker.pick(position);
+    if (handle) {
+      this.gizmo.setHover(handle.id);
+    } else {
+      this.gizmo.setHover(null);
+    }
+  }
+
+  _onPointerDown(position) {
+    if (!position) return;
+    const handle = this.picker.drillPick(position);
+    if (!handle) return;
+    this.currentHandle = handle;
+    this.gizmo.setActive(handle.id);
+    this.state = 'dragging';
+    this.hud.setVisible(true);
+    this._beginDrag(position, handle);
+  }
+
+  _beginDrag(position, handle) {
+    const camera = this.scene.camera;
+    const ray = camera.getPickRay(position);
+    if (!ray) return;
+    this._updateFrame();
+    const simpleRay = rayToSimple(ray);
+    const cameraDirection = cartesianToVector(camera.direction);
+    const pivot = this.pivotResolver.resolve(this.targets);
+    this.pivotData = pivot;
+    const startTransforms = this.targets.map((target) => {
+      const matrix = getTargetMatrix(target, this.Cesium);
+      const transform = decomposeTransform(matrix);
+      return { target, matrix, transform };
+    });
+    this.dragSession = {
+      handle,
+      startRay: simpleRay,
+      startTransforms,
+      pivot,
+    };
+
+    switch (handle.type) {
+      case 'translate-axis':
+        this.dragSession.operation = beginAxisTranslation({
+          axis: this.frame.axes[handle.axis],
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+          cameraDirection,
+        });
+        break;
+      case 'translate-plane':
+        this.dragSession.operation = beginPlaneTranslation({
+          planeNormal: this._planeNormalForHandle(handle),
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+        });
+        break;
+      case 'rotate-axis':
+        this.dragSession.operation = beginAxisRotation({
+          axis: this.frame.axes[handle.axis],
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+        });
+        break;
+      case 'rotate-view':
+        this.dragSession.operation = beginViewRotation({
+          viewDirection: cameraDirection,
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+        });
+        break;
+      case 'scale-axis':
+        this.dragSession.operation = beginAxisScale({
+          axis: this.frame.axes[handle.axis],
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+          cameraDirection,
+        });
+        break;
+      case 'scale-uniform':
+        this.dragSession.operation = beginUniformScale({
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+          cameraDirection,
+        });
+        break;
+      default:
+        break;
+    }
+  }
+
+  _updateDrag(position) {
+    if (!this.dragSession) return;
+    const camera = this.scene.camera;
+    const ray = camera.getPickRay(position);
+    if (!ray) return;
+    const simpleRay = rayToSimple(ray);
+    const modifiers = this._keyState;
+    const handle = this.dragSession.handle;
+    let delta;
+    switch (handle.type) {
+      case 'translate-axis': {
+        delta = updateAxisTranslation(this.dragSession.operation, simpleRay);
+        const snapped = this.snapper.snapTranslation(delta.distance, modifiers);
+        delta.vector = scaleVector(this.frame.axes[handle.axis], snapped);
+        this._applyTranslation(delta.vector);
+        this.hud.update({ mode: 'translate', axis: handle.axis, values: { [handle.axis]: snapped } });
+        break;
+      }
+      case 'translate-plane': {
+        delta = updatePlaneTranslation(this.dragSession.operation, simpleRay);
+        this._applyTranslation(delta.vector);
+        this.hud.update({ mode: 'translate', plane: handle.plane, values: delta.vector });
+        break;
+      }
+      case 'rotate-axis': {
+        delta = updateAxisRotation(this.dragSession.operation, simpleRay);
+        const angle = this.snapper.snapRotation(delta.angle, modifiers);
+        this._applyRotation(this.frame.axes[handle.axis], angle);
+        this.hud.update({ mode: 'rotate', axis: handle.axis, values: angle });
+        break;
+      }
+      case 'rotate-view': {
+        delta = updateAxisRotation(this.dragSession.operation, simpleRay);
+        const angle = this.snapper.snapRotation(delta.angle, modifiers);
+        this._applyRotation(cartesianToVector(camera.direction), angle);
+        this.hud.update({ mode: 'rotate', axis: 'view', values: angle });
+        break;
+      }
+      case 'scale-axis': {
+        delta = updateAxisScale(this.dragSession.operation, simpleRay);
+        const factor = this.snapper.snapScale(delta.scale, modifiers);
+        this._applyAxisScale(handle.axis, factor);
+        this.hud.update({ mode: 'scale', axis: handle.axis, values: factor });
+        break;
+      }
+      case 'scale-uniform': {
+        delta = updateUniformScale(this.dragSession.operation, simpleRay);
+        const factor = this.snapper.snapScale(delta.scale, modifiers);
+        this._applyUniformScale(factor);
+        this.hud.update({ mode: 'scale', axis: 'uniform', values: factor });
+        break;
+      }
+      default:
+        break;
+    }
+    this._updateFrame();
+  }
+
+  _applyTranslation(vector) {
+    this.dragSession.startTransforms.forEach((entry) => {
+      const translation = add(entry.transform.translation, vector);
+      const matrix = composeTransform(translation, entry.transform.rotation, entry.transform.scale);
+      setTargetMatrix(entry.target, matrix, this.Cesium);
+    });
+  }
+
+  _applyRotation(axisVector, angle) {
+    const rotationQuaternion = {
+      x: axisVector.x * Math.sin(angle / 2),
+      y: axisVector.y * Math.sin(angle / 2),
+      z: axisVector.z * Math.sin(angle / 2),
+      w: Math.cos(angle / 2),
+    };
+    this.dragSession.startTransforms.forEach((entry) => {
+      const pivot = this.pivotData.perTarget.get(entry.target) ?? this.pivotData.pivot;
+      const relative = subtract(entry.transform.translation, pivot);
+      const rotated = rotateVectorByQuaternion(relative, rotationQuaternion);
+      const translation = add(pivot, rotated);
+      const rotation = quaternionMultiply(rotationQuaternion, entry.transform.rotation);
+      const matrix = composeTransform(translation, rotation, entry.transform.scale);
+      setTargetMatrix(entry.target, matrix, this.Cesium);
+    });
+  }
+
+  _applyAxisScale(axis, factor) {
+    const axisVector = this.frame.axes[axis];
+    this.dragSession.startTransforms.forEach((entry) => {
+      const pivot = this.pivotData.perTarget.get(entry.target) ?? this.pivotData.pivot;
+      const relative = subtract(entry.transform.translation, pivot);
+      const along = projectOnVector(relative, axisVector);
+      const perpendicular = subtract(relative, along);
+      const scaledAlong = scaleVector(along, factor);
+      const translation = add(pivot, add(perpendicular, scaledAlong));
+      const scale = {
+        x: entry.transform.scale.x * (axis === 'x' ? factor : 1),
+        y: entry.transform.scale.y * (axis === 'y' ? factor : 1),
+        z: entry.transform.scale.z * (axis === 'z' ? factor : 1),
+      };
+      const matrix = composeTransform(translation, entry.transform.rotation, scale);
+      setTargetMatrix(entry.target, matrix, this.Cesium);
+    });
+  }
+
+  _applyUniformScale(factor) {
+    this.dragSession.startTransforms.forEach((entry) => {
+      const pivot = this.pivotData.perTarget.get(entry.target) ?? this.pivotData.pivot;
+      const relative = subtract(entry.transform.translation, pivot);
+      const translation = add(pivot, scaleVector(relative, factor));
+      const scale = {
+        x: entry.transform.scale.x * factor,
+        y: entry.transform.scale.y * factor,
+        z: entry.transform.scale.z * factor,
+      };
+      const matrix = composeTransform(translation, entry.transform.rotation, scale);
+      setTargetMatrix(entry.target, matrix, this.Cesium);
+    });
+  }
+
+  _planeNormalForHandle(handle) {
+    switch (handle.plane) {
+      case 'xy':
+        return this.frame.axes.z;
+      case 'yz':
+        return this.frame.axes.x;
+      case 'xz':
+        return this.frame.axes.y;
+      default:
+        return this.frame.axes.z;
+    }
+  }
+
+  _onPointerUp() {
+    if (this.state === 'dragging') {
+      this.state = 'idle';
+      this.gizmo.setActive(null);
+      this.hud.setVisible(false);
+      this.dragSession = null;
+    }
+  }
+
+  _cancelDrag() {
+    this.state = 'idle';
+    this.gizmo.setActive(null);
+    this.hud.setVisible(false);
+    this.dragSession = null;
+  }
+
+  destroy() {
+    this.handler?.destroy();
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('keydown', this._keyDownListener);
+      document.removeEventListener('keyup', this._keyUpListener);
+    }
+    this.hud.destroy();
+  }
+}

--- a/dist/PivotResolver.js
+++ b/dist/PivotResolver.js
@@ -1,0 +1,76 @@
+import { add, scale, ZERO_VECTOR } from './math.js';
+
+function extractTranslation(target) {
+  if (!target) return ZERO_VECTOR;
+  if (target.position) {
+    return target.position;
+  }
+  if (target.matrix) {
+    const m = target.matrix;
+    return { x: m[3], y: m[7], z: m[11] };
+  }
+  if (typeof target.getWorldMatrix === 'function') {
+    const m = target.getWorldMatrix();
+    return { x: m[3], y: m[7], z: m[11] };
+  }
+  return ZERO_VECTOR;
+}
+
+function averagePoints(points) {
+  if (!points.length) return ZERO_VECTOR;
+  const total = points.reduce((acc, point) => add(acc, point), ZERO_VECTOR);
+  return scale(total, 1 / points.length);
+}
+
+export class PivotResolver {
+  constructor() {
+    this.mode = 'origin';
+    this.cursor = ZERO_VECTOR;
+  }
+
+  setMode(mode) {
+    this.mode = mode;
+  }
+
+  setCursor(position) {
+    this.cursor = position;
+  }
+
+  resolve(targets, modeOverride) {
+    const mode = modeOverride ?? this.mode;
+    const targetArray = Array.isArray(targets) ? targets : [targets];
+    const positions = targetArray.map(extractTranslation);
+    if (!targetArray.length) {
+      return { pivot: ZERO_VECTOR, perTarget: new Map() };
+    }
+
+    if (mode === 'cursor') {
+      const map = new Map();
+      for (const target of targetArray) {
+        map.set(target, this.cursor);
+      }
+      return { pivot: this.cursor, perTarget: map };
+    }
+
+    if (mode === 'individual') {
+      const map = new Map();
+      targetArray.forEach((target, index) => {
+        map.set(target, positions[index]);
+      });
+      return { pivot: positions[0], perTarget: map };
+    }
+
+    if (mode === 'median') {
+      const pivot = averagePoints(positions);
+      const map = new Map();
+      targetArray.forEach((target) => map.set(target, pivot));
+      return { pivot, perTarget: map };
+    }
+
+    // origin fallback
+    const pivot = positions[0];
+    const map = new Map();
+    targetArray.forEach((target) => map.set(target, pivot));
+    return { pivot, perTarget: map };
+  }
+}

--- a/dist/Snapper.js
+++ b/dist/Snapper.js
@@ -1,0 +1,45 @@
+const DEFAULTS = {
+  translate: 1.0,
+  rotate: (5 * Math.PI) / 180,
+  scale: 0.1,
+};
+
+function resolveStep(base, modifiers) {
+  if (!base || base <= 0) return 0;
+  let step = base;
+  if (modifiers?.shiftKey) {
+    step *= 0.1;
+  }
+  if (modifiers?.altKey) {
+    step *= 0.25;
+  }
+  return step;
+}
+
+export class Snapper {
+  constructor(config = {}) {
+    this.steps = { ...DEFAULTS, ...config };
+  }
+
+  setConfig(config) {
+    this.steps = { ...this.steps, ...config };
+  }
+
+  snapTranslation(value, modifiers = {}) {
+    const step = resolveStep(this.steps.translate, modifiers);
+    if (!step || !modifiers?.ctrlKey) return value;
+    return Math.round(value / step) * step;
+  }
+
+  snapRotation(angle, modifiers = {}) {
+    const step = resolveStep(this.steps.rotate, modifiers);
+    if (!step || !modifiers?.ctrlKey) return angle;
+    return Math.round(angle / step) * step;
+  }
+
+  snapScale(scale, modifiers = {}) {
+    const step = resolveStep(this.steps.scale, modifiers);
+    if (!step || !modifiers?.ctrlKey) return scale;
+    return Math.round((scale - 1) / step) * step + 1;
+  }
+}

--- a/dist/TransformSolver.js
+++ b/dist/TransformSolver.js
@@ -1,0 +1,185 @@
+import {
+  add,
+  angleBetween,
+  clampMagnitude,
+  cross,
+  magnitude,
+  normalize,
+  projectScalar,
+  rayPlaneIntersection,
+  scale,
+  subtract,
+  ZERO_VECTOR,
+  fromAxisAngle,
+  quaternionMultiply,
+  IDENTITY_QUATERNION,
+} from './math.js';
+
+const EPSILON = 1e-6;
+
+function ensurePlaneNormal(axis, cameraDirection) {
+  let planeNormal = cross(axis, cameraDirection);
+  if (magnitude(planeNormal) < EPSILON) {
+    const fallback = Math.abs(axis.z) < 0.9 ? { x: 0, y: 0, z: 1 } : { x: 0, y: 1, z: 0 };
+    planeNormal = cross(axis, fallback);
+  }
+  const normal = cross(axis, planeNormal);
+  if (magnitude(normal) < EPSILON) {
+    return normalize(planeNormal);
+  }
+  return normalize(normal);
+}
+
+export function beginAxisTranslation({ axis, pivot, startRay, cameraDirection }) {
+  const axisNorm = normalize(axis);
+  const planeNormal = ensurePlaneNormal(axisNorm, normalize(cameraDirection));
+  const startPoint =
+    rayPlaneIntersection(startRay, planeNormal, pivot) ?? add(pivot, scale(axisNorm, 0));
+  return {
+    type: 'axis-translate',
+    axis: axisNorm,
+    pivot,
+    planeNormal,
+    startPoint,
+  };
+}
+
+export function updateAxisTranslation(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.planeNormal, session.pivot);
+  if (!point) {
+    return { distance: 0, vector: ZERO_VECTOR };
+  }
+  const deltaVector = subtract(point, session.startPoint);
+  const distance = projectScalar(deltaVector, session.axis);
+  const vector = scale(session.axis, distance);
+  return { distance, vector };
+}
+
+export function beginPlaneTranslation({ planeNormal, pivot, startRay }) {
+  const normal = normalize(planeNormal);
+  const startPoint = rayPlaneIntersection(startRay, normal, pivot) ?? pivot;
+  return {
+    type: 'plane-translate',
+    normal,
+    pivot,
+    startPoint,
+  };
+}
+
+export function updatePlaneTranslation(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.normal, session.pivot);
+  if (!point) {
+    return { vector: ZERO_VECTOR };
+  }
+  const vector = subtract(point, session.startPoint);
+  return { vector };
+}
+
+export function beginAxisRotation({ axis, pivot, startRay }) {
+  const normal = normalize(axis);
+  const startPoint = rayPlaneIntersection(startRay, normal, pivot);
+  const startVector = startPoint ? subtract(startPoint, pivot) : ZERO_VECTOR;
+  return {
+    type: 'axis-rotate',
+    axis: normal,
+    pivot,
+    startVector: startVector,
+    lastAngle: 0,
+  };
+}
+
+export function updateAxisRotation(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.axis, session.pivot);
+  if (!point) {
+    return { angle: 0, quaternion: IDENTITY_QUATERNION };
+  }
+  const vector = subtract(point, session.pivot);
+  if (magnitude(vector) < EPSILON || magnitude(session.startVector) < EPSILON) {
+    return { angle: 0, quaternion: IDENTITY_QUATERNION };
+  }
+  const angle = angleBetween(session.startVector, vector, session.axis);
+  session.lastAngle = angle;
+  const quaternion = fromAxisAngle(session.axis, angle);
+  return { angle, quaternion };
+}
+
+export function beginViewRotation({ viewDirection, pivot, startRay }) {
+  const axis = normalize(viewDirection);
+  return beginAxisRotation({ axis, pivot, startRay });
+}
+
+export function beginAxisScale({ axis, pivot, startRay, cameraDirection }) {
+  const axisNorm = normalize(axis);
+  const planeNormal = ensurePlaneNormal(axisNorm, cameraDirection);
+  const startPoint = rayPlaneIntersection(startRay, planeNormal, pivot) ?? pivot;
+  const referenceVector = subtract(startPoint, pivot);
+  const initialLength = Math.max(Math.abs(projectScalar(referenceVector, axisNorm)), EPSILON);
+  return {
+    type: 'axis-scale',
+    axis: axisNorm,
+    pivot,
+    planeNormal,
+    startPoint,
+    initialLength,
+  };
+}
+
+export function updateAxisScale(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.planeNormal, session.pivot);
+  if (!point) {
+    return { scale: 1 };
+  }
+  const deltaVector = subtract(point, session.startPoint);
+  const distance = projectScalar(deltaVector, session.axis);
+  const factor = clampMagnitude(1 + distance / session.initialLength);
+  return { scale: factor === 0 ? 1 : factor, axis: session.axis };
+}
+
+export function beginUniformScale({ pivot, startRay, cameraDirection }) {
+  const normal = normalize(cameraDirection);
+  const startPoint = rayPlaneIntersection(startRay, normal, pivot) ?? pivot;
+  const baseDistance = magnitude(subtract(startPoint, pivot));
+  return {
+    type: 'uniform-scale',
+    pivot,
+    normal,
+    startPoint,
+    baseDistance: Math.max(baseDistance, EPSILON),
+  };
+}
+
+export function updateUniformScale(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.normal, session.pivot);
+  if (!point) {
+    return { scale: 1 };
+  }
+  const distance = magnitude(subtract(point, session.pivot));
+  const factor = clampMagnitude(distance / session.baseDistance);
+  return { scale: factor === 0 ? 1 : factor };
+}
+
+export function accumulateTranslation(delta, current) {
+  return add(current ?? ZERO_VECTOR, delta);
+}
+
+export function accumulateRotation(deltaQuaternion, currentQuaternion) {
+  return quaternionMultiply(deltaQuaternion, currentQuaternion ?? IDENTITY_QUATERNION);
+}
+
+export function accumulateScale(deltaScale, currentScale) {
+  if (!currentScale) {
+    return { x: deltaScale.x ?? deltaScale, y: deltaScale.y ?? deltaScale, z: deltaScale.z ?? deltaScale };
+  }
+  if (typeof deltaScale === 'number') {
+    return {
+      x: currentScale.x * deltaScale,
+      y: currentScale.y * deltaScale,
+      z: currentScale.z * deltaScale,
+    };
+  }
+  return {
+    x: currentScale.x * (deltaScale.x ?? 1),
+    y: currentScale.y * (deltaScale.y ?? 1),
+    z: currentScale.z * (deltaScale.z ?? 1),
+  };
+}

--- a/dist/UniversalManipulator.js
+++ b/dist/UniversalManipulator.js
@@ -1,0 +1,123 @@
+import { GizmoPrimitive } from './GizmoPrimitive.js';
+import { GizmoPicker } from './GizmoPicker.js';
+import { ManipulatorController } from './ManipulatorController.js';
+import { FrameBuilder } from './FrameBuilder.js';
+import { Snapper } from './Snapper.js';
+import { PivotResolver } from './PivotResolver.js';
+import { HudOverlay } from './HudOverlay.js';
+
+export class UniversalManipulator {
+  constructor(options = {}) {
+    const {
+      Cesium,
+      viewer,
+      target = null,
+      mode = 'translate',
+      orientation = 'global',
+      pivot = 'origin',
+      snap = {},
+      size = {},
+      hudContainer = null,
+    } = options;
+
+    if (!Cesium) {
+      throw new Error('Cesium namespace must be provided to UniversalManipulator.');
+    }
+    if (!viewer) {
+      throw new Error('viewer is required to create UniversalManipulator.');
+    }
+
+    this.Cesium = Cesium;
+    this.viewer = viewer;
+    this.enabledModes = { translate: true, rotate: true, scale: true };
+
+    this.gizmo = new GizmoPrimitive({ Cesium, viewer, size });
+    this.picker = new GizmoPicker(viewer.scene, this.gizmo);
+    this.frameBuilder = new FrameBuilder({ Cesium });
+    this.snapper = new Snapper(snap);
+    this.pivotResolver = new PivotResolver();
+    this.hud = new HudOverlay({ container: hudContainer ?? (typeof viewer.container !== 'string' ? viewer.container : null) });
+
+    this.controller = new ManipulatorController({
+      Cesium,
+      viewer,
+      gizmo: this.gizmo,
+      picker: this.picker,
+      frameBuilder: this.frameBuilder,
+      snapper: this.snapper,
+      pivotResolver: this.pivotResolver,
+      hud: this.hud,
+    });
+
+    this._show = true;
+    this.setMode(mode);
+    this.setOrientation(orientation);
+    this.setPivot(pivot);
+    this.setSnap(snap);
+    if (target) {
+      this.setTarget(target);
+    }
+  }
+
+  get show() {
+    return this._show;
+  }
+
+  set show(value) {
+    this._show = Boolean(value);
+    this.gizmo.setShow(this._show);
+  }
+
+  setTarget(target) {
+    this.controller.setTargets(target);
+  }
+
+  setOrientation(orientation) {
+    this.controller.setOrientation(orientation);
+  }
+
+  setPivot(pivot) {
+    this.controller.setPivot(pivot);
+  }
+
+  setCursor(position) {
+    this.pivotResolver.setCursor(position);
+  }
+
+  setMode(mode) {
+    if (this.enabledModes && this.enabledModes[mode] === false) {
+      throw new Error(`Mode ${mode} is disabled.`);
+    }
+    this.mode = mode;
+    this.controller.setMode(mode);
+    this.gizmo.setMode(mode);
+  }
+
+  enable(config) {
+    this.enabledModes = { ...this.enabledModes, ...config };
+    if (this.mode && this.enabledModes[this.mode] === false) {
+      const fallback = Object.keys(this.enabledModes).find((key) => this.enabledModes[key]);
+      if (fallback) {
+        this.setMode(fallback);
+      }
+    }
+  }
+
+  setSnap(stepConfig) {
+    this.snapper.setConfig(stepConfig);
+  }
+
+  setSize(screenPixelRadius, minScale, maxScale) {
+    const updated = { ...this.gizmo.size };
+    if (screenPixelRadius !== undefined) updated.screenRadius = screenPixelRadius;
+    if (minScale !== undefined) updated.minScale = minScale;
+    if (maxScale !== undefined) updated.maxScale = maxScale;
+    this.gizmo.size = updated;
+  }
+
+  destroy() {
+    this.controller.destroy();
+    this.gizmo.destroy();
+    this.hud.destroy();
+  }
+}

--- a/dist/constants.js
+++ b/dist/constants.js
@@ -1,0 +1,45 @@
+export const AXIS_COLORS = {
+  x: { inactive: [1, 0.266, 0.266, 1], hover: [1, 0.5, 0.5, 1], active: [1, 0.8, 0.6, 1] },
+  y: { inactive: [0.266, 1, 0.266, 1], hover: [0.5, 1, 0.5, 1], active: [0.6, 1, 0.8, 1] },
+  z: { inactive: [0.266, 0.6, 1, 1], hover: [0.5, 0.7, 1, 1], active: [0.6, 0.85, 1, 1] },
+  view: { inactive: [1, 1, 1, 1], hover: [1, 1, 1, 1], active: [1, 1, 1, 1] },
+};
+
+export const HANDLE_TYPES = {
+  TRANSLATE_AXIS: 'translate-axis',
+  TRANSLATE_PLANE: 'translate-plane',
+  ROTATE_AXIS: 'rotate-axis',
+  ROTATE_VIEW: 'rotate-view',
+  SCALE_AXIS: 'scale-axis',
+  SCALE_UNIFORM: 'scale-uniform',
+};
+
+export const MODE_HANDLES = {
+  translate: ['x', 'y', 'z', 'xy', 'yz', 'xz'],
+  rotate: ['x', 'y', 'z', 'view'],
+  scale: ['x', 'y', 'z', 'uniform'],
+};
+
+export const AXIS_VECTORS = {
+  x: { x: 1, y: 0, z: 0 },
+  y: { x: 0, y: 1, z: 0 },
+  z: { x: 0, y: 0, z: 1 },
+};
+
+export const PLANE_NORMALS = {
+  xy: { x: 0, y: 0, z: 1 },
+  yz: { x: 1, y: 0, z: 0 },
+  xz: { x: 0, y: 1, z: 0 },
+};
+
+export const DEFAULT_SIZE = {
+  screenRadius: 110,
+  minScale: 0.2,
+  maxScale: 2.5,
+};
+
+export const MODE_TO_HANDLE_TYPE = {
+  translate: HANDLE_TYPES.TRANSLATE_AXIS,
+  rotate: HANDLE_TYPES.ROTATE_AXIS,
+  scale: HANDLE_TYPES.SCALE_AXIS,
+};

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,9 @@
+export { UniversalManipulator } from './UniversalManipulator.js';
+export { GizmoPrimitive } from './GizmoPrimitive.js';
+export { GizmoPicker } from './GizmoPicker.js';
+export { ManipulatorController } from './ManipulatorController.js';
+export { FrameBuilder } from './FrameBuilder.js';
+export { PivotResolver } from './PivotResolver.js';
+export { Snapper } from './Snapper.js';
+export * as math from './math.js';
+export * as TransformSolver from './TransformSolver.js';

--- a/dist/math.js
+++ b/dist/math.js
@@ -1,0 +1,300 @@
+const EPSILON = 1e-10;
+
+export function clone(v) {
+  return { x: v.x, y: v.y, z: v.z };
+}
+
+export function add(a, b) {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+export function subtract(a, b) {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+export function scale(v, scalar) {
+  return { x: v.x * scalar, y: v.y * scalar, z: v.z * scalar };
+}
+
+export function dot(a, b) {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+export function cross(a, b) {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+export function magnitude(v) {
+  return Math.sqrt(dot(v, v));
+}
+
+export function normalize(v) {
+  const mag = magnitude(v);
+  if (mag < EPSILON) {
+    return { x: 0, y: 0, z: 0 };
+  }
+  return scale(v, 1 / mag);
+}
+
+export function equalsEpsilon(a, b, epsilon = EPSILON) {
+  return (
+    Math.abs(a.x - b.x) <= epsilon &&
+    Math.abs(a.y - b.y) <= epsilon &&
+    Math.abs(a.z - b.z) <= epsilon
+  );
+}
+
+export function equalsQuaternion(a, b, epsilon = EPSILON) {
+  if (!a || !b) return false;
+  const diff = Math.abs(a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w);
+  return Math.abs(1 - diff) <= epsilon;
+}
+
+export function fromAxisAngle(axis, angle) {
+  const half = angle * 0.5;
+  const s = Math.sin(half);
+  const norm = normalize(axis);
+  return {
+    x: norm.x * s,
+    y: norm.y * s,
+    z: norm.z * s,
+    w: Math.cos(half),
+  };
+}
+
+export function quaternionMultiply(a, b) {
+  return {
+    w: a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z,
+    x: a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+    y: a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+    z: a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
+  };
+}
+
+export function rotateVectorByQuaternion(vector, quaternion) {
+  const qVec = { x: quaternion.x, y: quaternion.y, z: quaternion.z };
+  const uv = cross(qVec, vector);
+  const uuv = cross(qVec, uv);
+  const uvScaled = scale(uv, 2 * quaternion.w);
+  const uuvScaled = scale(uuv, 2);
+  return add(vector, add(uvScaled, uuvScaled));
+}
+
+export function quaternionToMatrix(q) {
+  const xx = q.x * q.x;
+  const yy = q.y * q.y;
+  const zz = q.z * q.z;
+  const xy = q.x * q.y;
+  const xz = q.x * q.z;
+  const yz = q.y * q.z;
+  const wx = q.w * q.x;
+  const wy = q.w * q.y;
+  const wz = q.w * q.z;
+
+  return [
+    1 - 2 * (yy + zz), 2 * (xy - wz), 2 * (xz + wy),
+    2 * (xy + wz), 1 - 2 * (xx + zz), 2 * (yz - wx),
+    2 * (xz - wy), 2 * (yz + wx), 1 - 2 * (xx + yy),
+  ];
+}
+
+export function matrixToQuaternion(m) {
+  const trace = m[0] + m[4] + m[8];
+  let q = { x: 0, y: 0, z: 0, w: 1 };
+  if (trace > 0) {
+    const s = Math.sqrt(trace + 1.0) * 2;
+    q.w = 0.25 * s;
+    q.x = (m[7] - m[5]) / s;
+    q.y = (m[2] - m[6]) / s;
+    q.z = (m[3] - m[1]) / s;
+  } else if (m[0] > m[4] && m[0] > m[8]) {
+    const s = Math.sqrt(1.0 + m[0] - m[4] - m[8]) * 2;
+    q.w = (m[7] - m[5]) / s;
+    q.x = 0.25 * s;
+    q.y = (m[1] + m[3]) / s;
+    q.z = (m[2] + m[6]) / s;
+  } else if (m[4] > m[8]) {
+    const s = Math.sqrt(1.0 + m[4] - m[0] - m[8]) * 2;
+    q.w = (m[2] - m[6]) / s;
+    q.x = (m[1] + m[3]) / s;
+    q.y = 0.25 * s;
+    q.z = (m[5] + m[7]) / s;
+  } else {
+    const s = Math.sqrt(1.0 + m[8] - m[0] - m[4]) * 2;
+    q.w = (m[3] - m[1]) / s;
+    q.x = (m[2] + m[6]) / s;
+    q.y = (m[5] + m[7]) / s;
+    q.z = 0.25 * s;
+  }
+  return normalizeQuaternion(q);
+}
+
+export function normalizeQuaternion(q) {
+  const len = Math.sqrt(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
+  if (len < EPSILON) {
+    return { x: 0, y: 0, z: 0, w: 1 };
+  }
+  return { x: q.x / len, y: q.y / len, z: q.z / len, w: q.w / len };
+}
+
+export function composeTransform(translation, rotation, scaleVec) {
+  const m = quaternionToMatrix(rotation);
+  return [
+    m[0] * scaleVec.x, m[1] * scaleVec.y, m[2] * scaleVec.z, 0,
+    m[3] * scaleVec.x, m[4] * scaleVec.y, m[5] * scaleVec.z, 0,
+    m[6] * scaleVec.x, m[7] * scaleVec.y, m[8] * scaleVec.z, 0,
+    translation.x, translation.y, translation.z, 1,
+  ];
+}
+
+export function decomposeTransform(matrix) {
+  const translation = { x: matrix[12], y: matrix[13], z: matrix[14] };
+  const basisX = { x: matrix[0], y: matrix[4], z: matrix[8] };
+  const basisY = { x: matrix[1], y: matrix[5], z: matrix[9] };
+  const basisZ = { x: matrix[2], y: matrix[6], z: matrix[10] };
+  const scale = {
+    x: magnitude(basisX),
+    y: magnitude(basisY),
+    z: magnitude(basisZ),
+  };
+  const invScale = {
+    x: scale.x > EPSILON ? 1 / scale.x : 0,
+    y: scale.y > EPSILON ? 1 / scale.y : 0,
+    z: scale.z > EPSILON ? 1 / scale.z : 0,
+  };
+  const rotMatrix = [
+    basisX.x * invScale.x, basisY.x * invScale.y, basisZ.x * invScale.z,
+    basisX.y * invScale.x, basisY.y * invScale.y, basisZ.y * invScale.z,
+    basisX.z * invScale.x, basisY.z * invScale.y, basisZ.z * invScale.z,
+  ];
+  const rotation = matrixToQuaternion(rotMatrix);
+  return { translation, rotation, scale };
+}
+
+export function projectOnVector(vector, axis) {
+  const axisNorm = normalize(axis);
+  return scale(axisNorm, dot(vector, axisNorm));
+}
+
+export function projectScalar(vector, axis) {
+  const axisNorm = normalize(axis);
+  return dot(vector, axisNorm);
+}
+
+export function angleBetween(a, b, normal) {
+  const aNorm = normalize(a);
+  const bNorm = normalize(b);
+  const crossProd = cross(aNorm, bNorm);
+  const sin = magnitude(crossProd);
+  const cos = dot(aNorm, bNorm);
+  let angle = Math.atan2(sin, cos);
+  if (normal && dot(crossProd, normal) < 0) {
+    angle = -angle;
+  }
+  return angle;
+}
+
+export function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function toMatrix4(columns) {
+  return [
+    columns[0].x, columns[1].x, columns[2].x, columns[3]?.x ?? 0,
+    columns[0].y, columns[1].y, columns[2].y, columns[3]?.y ?? 0,
+    columns[0].z, columns[1].z, columns[2].z, columns[3]?.z ?? 0,
+    0, 0, 0, 1,
+  ];
+}
+
+export function orthonormalize(basisX, basisY, basisZ) {
+  const x = normalize(basisX);
+  const z = normalize(cross(x, basisY));
+  const y = normalize(cross(z, x));
+  return { x, y, z };
+}
+
+export function buildLookAt(forward, up) {
+  const z = normalize(forward);
+  const x = normalize(cross(up, z));
+  const y = cross(z, x);
+  return { x, y, z };
+}
+
+export function ensureOrthogonalAxes(axes) {
+  const { x, y, z } = axes;
+  const ortho = orthonormalize(x, y, z);
+  return { x: ortho.x, y: ortho.y, z: ortho.z };
+}
+
+export function nearlyZero(value, epsilon = EPSILON) {
+  return Math.abs(value) <= epsilon;
+}
+
+export function clampMagnitude(value, epsilon = EPSILON) {
+  return nearlyZero(value, epsilon) ? 0 : value;
+}
+
+export function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+export function lerpVector(a, b, t) {
+  return {
+    x: lerp(a.x, b.x, t),
+    y: lerp(a.y, b.y, t),
+    z: lerp(a.z, b.z, t),
+  };
+}
+
+export function quaternionSlerp(a, b, t) {
+  let cosHalfTheta = a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z;
+  if (cosHalfTheta < 0) {
+    b = { x: -b.x, y: -b.y, z: -b.z, w: -b.w };
+    cosHalfTheta = -cosHalfTheta;
+  }
+  if (Math.abs(cosHalfTheta) >= 1.0) {
+    return { ...a };
+  }
+  const halfTheta = Math.acos(cosHalfTheta);
+  const sinHalfTheta = Math.sqrt(1.0 - cosHalfTheta * cosHalfTheta);
+  if (Math.abs(sinHalfTheta) < EPSILON) {
+    return {
+      w: 0.5 * (a.w + b.w),
+      x: 0.5 * (a.x + b.x),
+      y: 0.5 * (a.y + b.y),
+      z: 0.5 * (a.z + b.z),
+    };
+  }
+  const ratioA = Math.sin((1 - t) * halfTheta) / sinHalfTheta;
+  const ratioB = Math.sin(t * halfTheta) / sinHalfTheta;
+  return {
+    w: a.w * ratioA + b.w * ratioB,
+    x: a.x * ratioA + b.x * ratioB,
+    y: a.y * ratioA + b.y * ratioB,
+    z: a.z * ratioA + b.z * ratioB,
+  };
+}
+
+export function rayPlaneIntersection(ray, planeNormal, planePoint) {
+  const denom = dot(ray.direction, planeNormal);
+  if (nearlyZero(denom)) {
+    return null;
+  }
+  const diff = subtract(planePoint, ray.origin);
+  const t = dot(diff, planeNormal) / denom;
+  if (t < 0) {
+    return null;
+  }
+  return add(ray.origin, scale(ray.direction, t));
+}
+
+export const IDENTITY_QUATERNION = { x: 0, y: 0, z: 0, w: 1 };
+export const ZERO_VECTOR = { x: 0, y: 0, z: 0 };
+export const UNIT_X = { x: 1, y: 0, z: 0 };
+export const UNIT_Y = { x: 0, y: 1, z: 0 };
+export const UNIT_Z = { x: 0, y: 0, z: 1 };

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,39 +3,16 @@
   <head>
     <meta charset="utf-8" />
     <title>Cesium Universal Manipulator Demo</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/cesium/1.133/Cesium.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cesium/1.133/Widgets/widgets.css" />
-    <style>
-      html,
-      body,
-      #cesiumContainer {
-        width: 100%;
-        height: 100%;
-        margin: 0;
-        padding: 0;
-        overflow: hidden;
-        background: #0b1a2a;
-      }
-      .panel {
-        position: absolute;
-        top: 12px;
-        left: 12px;
-        padding: 12px;
-        background: rgba(0, 0, 0, 0.6);
-        color: #fff;
-        font-family: sans-serif;
-        border-radius: 6px;
-      }
-      .panel label {
-        display: block;
-        margin-bottom: 4px;
-      }
-      .panel select,
-      .panel input {
-        width: 120px;
-        margin-bottom: 6px;
-      }
-    </style>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/cesium@1.133.0/Build/Cesium/Widgets/widgets.css"
+    />
+    <link rel="stylesheet" href="src/styles.css" />
+    <script>
+      window.CESIUM_BASE_URL =
+        'https://cdn.jsdelivr.net/npm/cesium@1.133.0/Build/Cesium/';
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/cesium@1.133.0/Build/Cesium/Cesium.js"></script>
   </head>
   <body>
     <div id="cesiumContainer"></div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Cesium Universal Manipulator Demo</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/cesium/1.133/Cesium.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cesium/1.133/Widgets/widgets.css" />
+    <style>
+      html,
+      body,
+      #cesiumContainer {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        background: #0b1a2a;
+      }
+      .panel {
+        position: absolute;
+        top: 12px;
+        left: 12px;
+        padding: 12px;
+        background: rgba(0, 0, 0, 0.6);
+        color: #fff;
+        font-family: sans-serif;
+        border-radius: 6px;
+      }
+      .panel label {
+        display: block;
+        margin-bottom: 4px;
+      }
+      .panel select,
+      .panel input {
+        width: 120px;
+        margin-bottom: 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="cesiumContainer"></div>
+    <div class="panel">
+      <label>
+        Mode
+        <select id="mode">
+          <option value="translate">Translate</option>
+          <option value="rotate">Rotate</option>
+          <option value="scale">Scale</option>
+        </select>
+      </label>
+      <label>
+        Orientation
+        <select id="orientation">
+          <option value="global">Global</option>
+          <option value="local">Local</option>
+          <option value="view">View</option>
+          <option value="enu">ENU</option>
+        </select>
+      </label>
+      <label>
+        Pivot
+        <select id="pivot">
+          <option value="origin">Origin</option>
+          <option value="median">Median</option>
+          <option value="cursor">Cursor</option>
+          <option value="individual">Individual</option>
+        </select>
+      </label>
+      <label>
+        Snap (meters)
+        <input id="snap-translate" type="number" value="1" step="0.1" />
+      </label>
+      <label>
+        Snap (degrees)
+        <input id="snap-rotate" type="number" value="5" step="1" />
+      </label>
+      <label>
+        Snap (scale)
+        <input id="snap-scale" type="number" value="0.1" step="0.1" />
+      </label>
+    </div>
+    <script type="module">
+      import { UniversalManipulator } from '../src/index.js';
+
+      const viewer = new Cesium.Viewer('cesiumContainer', {
+        shouldAnimate: true,
+      });
+
+      viewer.scene.globe.enableLighting = true;
+
+      const redBox = viewer.entities.add({
+        name: 'Red box',
+        position: Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883, 100),
+        box: {
+          dimensions: new Cesium.Cartesian3(30, 30, 30),
+          material: Cesium.Color.RED.withAlpha(0.8),
+        },
+      });
+
+      const greenBox = viewer.entities.add({
+        name: 'Green box',
+        position: Cesium.Cartesian3.fromDegrees(-75.6, 40.04, 100),
+        box: {
+          dimensions: new Cesium.Cartesian3(20, 20, 40),
+          material: Cesium.Color.LIME.withAlpha(0.8),
+        },
+      });
+
+      viewer.zoomTo(viewer.entities);
+
+      const manipulator = new UniversalManipulator({
+        Cesium,
+        viewer,
+        target: [redBox, greenBox],
+        mode: 'translate',
+      });
+
+      const modeSelect = document.getElementById('mode');
+      const orientationSelect = document.getElementById('orientation');
+      const pivotSelect = document.getElementById('pivot');
+      const snapTranslate = document.getElementById('snap-translate');
+      const snapRotate = document.getElementById('snap-rotate');
+      const snapScale = document.getElementById('snap-scale');
+
+      modeSelect.addEventListener('change', () => {
+        manipulator.setMode(modeSelect.value);
+      });
+      orientationSelect.addEventListener('change', () => {
+        manipulator.setOrientation(orientationSelect.value);
+      });
+      pivotSelect.addEventListener('change', () => {
+        manipulator.setPivot(pivotSelect.value);
+      });
+
+      function updateSnap() {
+        manipulator.setSnap({
+          translate: Number(snapTranslate.value),
+          rotate: (Number(snapRotate.value) * Math.PI) / 180,
+          scale: Number(snapScale.value),
+        });
+      }
+
+      snapTranslate.addEventListener('input', updateSnap);
+      snapRotate.addEventListener('input', updateSnap);
+      snapScale.addEventListener('input', updateSnap);
+      updateSnap();
+    </script>
+  </body>
+</html>

--- a/examples/src/styles.css
+++ b/examples/src/styles.css
@@ -1,0 +1,32 @@
+html,
+body,
+#cesiumContainer {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background: #0b1a2a;
+}
+
+.panel {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-family: sans-serif;
+  border-radius: 6px;
+}
+
+.panel label {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.panel select,
+.panel input {
+  width: 120px;
+  margin-bottom: 6px;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "cesium-universal-manipulator",
+  "version": "0.1.0",
+  "description": "Universal translation/rotation/scale manipulator for CesiumJS scenes.",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
+  "scripts": {
+    "build": "node scripts/build.js",
+    "test": "node tests/run-tests.js"
+  },
+  "keywords": [
+    "cesium",
+    "manipulator",
+    "gizmo",
+    "3d",
+    "transform"
+  ],
+  "author": "",
+  "license": "MIT",
+  "peerDependencies": {
+    "cesium": ">=1.133.0"
+  }
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { cpSync, mkdirSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const dist = resolve(repoRoot, 'dist');
+
+rmSync(dist, { recursive: true, force: true });
+mkdirSync(dist, { recursive: true });
+cpSync(resolve(repoRoot, 'src'), resolve(dist), { recursive: true });
+console.log('Copied source files to dist/.');

--- a/src/FrameBuilder.js
+++ b/src/FrameBuilder.js
@@ -1,0 +1,113 @@
+import {
+  IDENTITY_QUATERNION,
+  UNIT_X,
+  UNIT_Y,
+  UNIT_Z,
+  buildLookAt,
+  decomposeTransform,
+  ensureOrthogonalAxes,
+  normalize,
+  quaternionToMatrix,
+  ZERO_VECTOR,
+} from './math.js';
+
+function extractMatrix(target) {
+  if (!target) {
+    return null;
+  }
+  if (target.matrix) {
+    return target.matrix;
+  }
+  if (target.modelMatrix) {
+    return target.modelMatrix;
+  }
+  if (typeof target.getWorldMatrix === 'function') {
+    return target.getWorldMatrix();
+  }
+  if (target.entity && target.entity.computeModelMatrix) {
+    return target.entity.computeModelMatrix(Date.now());
+  }
+  return null;
+}
+
+function matrixAxes(rotationMatrix) {
+  return {
+    x: { x: rotationMatrix[0], y: rotationMatrix[3], z: rotationMatrix[6] },
+    y: { x: rotationMatrix[1], y: rotationMatrix[4], z: rotationMatrix[7] },
+    z: { x: rotationMatrix[2], y: rotationMatrix[5], z: rotationMatrix[8] },
+  };
+}
+
+function fromRotation(quaternion) {
+  const matrix = quaternionToMatrix(quaternion);
+  return matrixAxes(matrix);
+}
+
+function computeENU(position, cesium, ellipsoid) {
+  if (cesium?.Transforms?.eastNorthUpToFixedFrame) {
+    const matrix = cesium.Transforms.eastNorthUpToFixedFrame(position, ellipsoid);
+    return {
+      origin: position,
+      axes: {
+        x: { x: matrix[0], y: matrix[4], z: matrix[8] },
+        y: { x: matrix[1], y: matrix[5], z: matrix[9] },
+        z: { x: matrix[2], y: matrix[6], z: matrix[10] },
+      },
+    };
+  }
+  return { origin: position, axes: { x: UNIT_X, y: UNIT_Y, z: UNIT_Z } };
+}
+
+export class FrameBuilder {
+  constructor(options = {}) {
+    this.cesium = options.cesium;
+    this.ellipsoid = options.ellipsoid ?? options.cesium?.Ellipsoid?.WGS84;
+  }
+
+  buildFrame({ target, orientation = 'global', camera, normal, gimbalYaw = 0, gimbalPitch = 0 }) {
+    const matrix = extractMatrix(target);
+    let origin = ZERO_VECTOR;
+    let rotation = IDENTITY_QUATERNION;
+    if (matrix) {
+      const decomposed = decomposeTransform(matrix);
+      origin = decomposed.translation;
+      rotation = decomposed.rotation;
+    }
+
+    switch (orientation) {
+      case 'global':
+        return { origin, axes: { x: UNIT_X, y: UNIT_Y, z: UNIT_Z } };
+      case 'local': {
+        const axes = ensureOrthogonalAxes(fromRotation(rotation));
+        return { origin, axes };
+      }
+      case 'view': {
+        if (!camera) {
+          return { origin, axes: { x: UNIT_X, y: UNIT_Y, z: UNIT_Z } };
+        }
+        const axes = {
+          x: camera.right ?? UNIT_X,
+          y: camera.up ?? UNIT_Y,
+          z: camera.direction ? normalize(camera.direction) : UNIT_Z,
+        };
+        return { origin, axes: ensureOrthogonalAxes(axes) };
+      }
+      case 'enu': {
+        return computeENU(origin, this.cesium, this.ellipsoid);
+      }
+      case 'normal': {
+        const referenceNormal = normal ?? UNIT_Z;
+        const axes = buildLookAt(referenceNormal, UNIT_Z);
+        return { origin, axes: ensureOrthogonalAxes(axes) };
+      }
+      case 'gimbal': {
+        const yawAxis = { x: Math.cos(gimbalYaw), y: 0, z: Math.sin(gimbalYaw) };
+        const pitchAxis = { x: 0, y: Math.cos(gimbalPitch), z: Math.sin(gimbalPitch) };
+        const axes = ensureOrthogonalAxes({ x: yawAxis, y: pitchAxis, z: UNIT_Z });
+        return { origin, axes };
+      }
+      default:
+        return { origin, axes: { x: UNIT_X, y: UNIT_Y, z: UNIT_Z } };
+    }
+  }
+}

--- a/src/GizmoPicker.js
+++ b/src/GizmoPicker.js
@@ -1,0 +1,46 @@
+export class GizmoPicker {
+  constructor(scene, gizmo) {
+    this.scene = scene;
+    this.gizmo = gizmo;
+  }
+
+  pick(position) {
+    if (!this.scene) return null;
+    const picked = this.scene.pick(position);
+    if (!picked) return null;
+    const entity = picked.id ?? picked;
+    const id = typeof entity === 'string' ? entity : entity.id;
+    if (!id) return null;
+    const handle = this.gizmo.handles.get(id);
+    if (!handle) return null;
+    return {
+      id,
+      mode: handle.mode,
+      axis: handle.axis,
+      plane: handle.plane,
+      type: handle.type,
+      entity,
+    };
+  }
+
+  drillPick(position) {
+    const picks = this.scene.drillPick(position, 5);
+    for (const picked of picks) {
+      const entity = picked.id ?? picked;
+      const id = typeof entity === 'string' ? entity : entity.id;
+      if (!id) continue;
+      const handle = this.gizmo.handles.get(id);
+      if (handle) {
+        return {
+          id,
+          mode: handle.mode,
+          axis: handle.axis,
+          plane: handle.plane,
+          type: handle.type,
+          entity,
+        };
+      }
+    }
+    return null;
+  }
+}

--- a/src/GizmoPrimitive.js
+++ b/src/GizmoPrimitive.js
@@ -1,0 +1,433 @@
+import { AXIS_COLORS, HANDLE_TYPES, MODE_HANDLES } from './constants.js';
+
+function colorFromArray(Cesium, array) {
+  return new Cesium.Color(array[0], array[1], array[2], array[3]);
+}
+
+function toCartesian3(Cesium, vector) {
+  return new Cesium.Cartesian3(vector.x, vector.y, vector.z);
+}
+
+function computeWorldScale(Cesium, scene, camera, origin, size) {
+  const distance = Cesium.Cartesian3.distance(camera.position, origin);
+  const canvas = scene.canvas;
+  const frustum = camera.frustum;
+  const fov = frustum.fovy ?? frustum.fov ?? Math.PI / 3;
+  const metersPerPixel = (2 * distance * Math.tan(fov * 0.5)) / canvas.height;
+  let scale = metersPerPixel * size.screenRadius;
+  const minWorld = size.minScale * distance;
+  const maxWorld = size.maxScale * distance;
+  scale = Cesium.Math.clamp(scale, minWorld, maxWorld);
+  return scale;
+}
+
+function unitCirclePoints(Cesium, axesA, axesB, origin, radius, segments) {
+  const positions = [];
+  for (let i = 0; i <= segments; i++) {
+    const t = (i / segments) * Math.PI * 2;
+    const local = {
+      x: Math.cos(t) * radius,
+      y: Math.sin(t) * radius,
+      z: 0,
+    };
+    const axisOffset = Cesium.Cartesian3.add(
+      Cesium.Cartesian3.multiplyByScalar(axesA, local.x, new Cesium.Cartesian3()),
+      Cesium.Cartesian3.multiplyByScalar(axesB, local.y, new Cesium.Cartesian3()),
+      new Cesium.Cartesian3()
+    );
+    positions.push(Cesium.Cartesian3.add(origin, axisOffset, axisOffset));
+  }
+  return positions;
+}
+
+function planeSquare(Cesium, origin, axisA, axisB, size) {
+  const half = size * 0.5;
+  const corners = [
+    { x: 0, y: 0, z: 0 },
+    { x: half, y: 0, z: 0 },
+    { x: half, y: half, z: 0 },
+    { x: 0, y: half, z: 0 },
+  ];
+  return corners.map((corner) =>
+    Cesium.Cartesian3.add(
+      origin,
+      Cesium.Cartesian3.add(
+        Cesium.Cartesian3.multiplyByScalar(axisA, corner.x * 2, new Cesium.Cartesian3()),
+        Cesium.Cartesian3.multiplyByScalar(axisB, corner.y * 2, new Cesium.Cartesian3()),
+        new Cesium.Cartesian3()
+      ),
+      new Cesium.Cartesian3()
+    )
+  );
+}
+
+export class GizmoPrimitive {
+  constructor({ Cesium, viewer, colors = {}, size = {} }) {
+    if (!Cesium) {
+      throw new Error('Cesium namespace is required to create GizmoPrimitive.');
+    }
+    this.Cesium = Cesium;
+    this.viewer = viewer;
+    this.scene = viewer.scene;
+    this.colors = {
+      x: { ...AXIS_COLORS.x, ...colors.x },
+      y: { ...AXIS_COLORS.y, ...colors.y },
+      z: { ...AXIS_COLORS.z, ...colors.z },
+      view: { ...AXIS_COLORS.view, ...colors.view },
+    };
+    this.size = { ...DEFAULT_SIZE, ...size };
+    this.handles = new Map();
+    this.entities = [];
+    this.show = true;
+    this.activeHandle = null;
+    this.hoverHandle = null;
+    this._createHandles();
+  }
+
+  _createHandles() {
+    this._createTranslationAxes();
+    this._createTranslationPlanes();
+    this._createScaleHandles();
+    this._createRotationRings();
+    this._createUniformScale();
+    this.mode = 'translate';
+    this._applyVisibility();
+  }
+
+  _createEntity(handleId, options) {
+    const entity = this.viewer.entities.add({
+      id: handleId,
+      show: true,
+      ...options,
+    });
+    this.entities.push(entity);
+    return entity;
+  }
+
+  _createTranslationAxes() {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const color = colorFromArray(Cesium, this.colors[axis].inactive);
+      const entity = this._createEntity(`translate-${axis}`, {
+        polyline: {
+          positions: [Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO],
+          width: 4,
+          material: color,
+          followSurface: false,
+          clampToGround: false,
+          classificationType: Cesium.ClassificationType.NONE,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+        point: {
+          pixelSize: 16,
+          color,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+      entity.properties = new Cesium.PropertyBag({
+        axis,
+        mode: 'translate',
+        type: HANDLE_TYPES.TRANSLATE_AXIS,
+      });
+      this.handles.set(`translate-${axis}`, { entity, axis, mode: 'translate', type: HANDLE_TYPES.TRANSLATE_AXIS });
+    });
+  }
+
+  _createTranslationPlanes() {
+    const Cesium = this.Cesium;
+    [['xy', 'z'], ['yz', 'x'], ['xz', 'y']].forEach(([plane, axis]) => {
+      const color = colorFromArray(Cesium, this.colors[axis].inactive);
+      const entity = this._createEntity(`translate-${plane}`, {
+        polygon: {
+          hierarchy: new Cesium.PolygonHierarchy([Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO]),
+          material: color.withAlpha(0.2),
+          classificationType: Cesium.ClassificationType.NONE,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+        polyline: {
+          positions: [Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO],
+          width: 2,
+          material: color,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+      entity.properties = new Cesium.PropertyBag({
+        mode: 'translate',
+        plane,
+        axis,
+        type: HANDLE_TYPES.TRANSLATE_PLANE,
+      });
+      this.handles.set(`translate-${plane}`, { entity, plane, mode: 'translate', type: HANDLE_TYPES.TRANSLATE_PLANE });
+    });
+  }
+
+  _createScaleHandles() {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const color = colorFromArray(Cesium, this.colors[axis].inactive);
+      const entity = this._createEntity(`scale-${axis}`, {
+        polyline: {
+          positions: [Cesium.Cartesian3.ZERO, Cesium.Cartesian3.ZERO],
+          width: 3,
+          material: color,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+        billboard: {
+          image: this._createSquareTexture(color),
+          width: 22,
+          height: 22,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+      entity.properties = new Cesium.PropertyBag({
+        axis,
+        mode: 'scale',
+        type: HANDLE_TYPES.SCALE_AXIS,
+      });
+      this.handles.set(`scale-${axis}`, { entity, axis, mode: 'scale', type: HANDLE_TYPES.SCALE_AXIS });
+    });
+  }
+
+  _createRotationRings() {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const color = colorFromArray(Cesium, this.colors[axis].inactive);
+      const entity = this._createEntity(`rotate-${axis}`, {
+        polyline: {
+          positions: new Array(65).fill(Cesium.Cartesian3.ZERO),
+          width: 2,
+          material: color,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+      entity.properties = new Cesium.PropertyBag({
+        axis,
+        mode: 'rotate',
+        type: HANDLE_TYPES.ROTATE_AXIS,
+      });
+      this.handles.set(`rotate-${axis}`, { entity, axis, mode: 'rotate', type: HANDLE_TYPES.ROTATE_AXIS });
+    });
+
+    const viewColor = colorFromArray(Cesium, this.colors.view.inactive);
+    const viewEntity = this._createEntity('rotate-view', {
+      polyline: {
+        positions: new Array(65).fill(Cesium.Cartesian3.ZERO),
+        width: 2,
+        material: viewColor,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+      },
+    });
+    viewEntity.properties = new Cesium.PropertyBag({
+      mode: 'rotate',
+      type: HANDLE_TYPES.ROTATE_VIEW,
+    });
+    this.handles.set('rotate-view', { entity: viewEntity, mode: 'rotate', type: HANDLE_TYPES.ROTATE_VIEW });
+  }
+
+  _createUniformScale() {
+    const Cesium = this.Cesium;
+    const color = colorFromArray(Cesium, this.colors.view.inactive);
+    const entity = this._createEntity('scale-uniform', {
+      point: {
+        pixelSize: 18,
+        color,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+      },
+    });
+    entity.properties = new Cesium.PropertyBag({
+      mode: 'scale',
+      type: HANDLE_TYPES.SCALE_UNIFORM,
+    });
+    this.handles.set('scale-uniform', { entity, mode: 'scale', type: HANDLE_TYPES.SCALE_UNIFORM });
+  }
+
+  _createSquareTexture(color) {
+    const size = 32;
+    if (typeof document === 'undefined') {
+      return color.toCssColorString();
+    }
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const context = canvas.getContext('2d');
+    context.fillStyle = color.toCssColorString();
+    context.fillRect(0, 0, size, size);
+    context.clearRect(6, 6, size - 12, size - 12);
+    context.lineWidth = 2;
+    context.strokeStyle = color.toCssColorString();
+    context.strokeRect(4, 4, size - 8, size - 8);
+    return canvas;
+  }
+
+  setShow(show) {
+    this.show = show;
+    this._applyVisibility();
+  }
+
+  setMode(mode) {
+    this.mode = mode;
+    this._applyVisibility();
+  }
+
+  _applyVisibility() {
+    this.entities.forEach((entity) => {
+      const handle = this.handles.get(entity.id);
+      const isModeMatch = handle?.mode === this.mode;
+      entity.show = Boolean(this.show && isModeMatch);
+    });
+  }
+
+  update(frame, camera, options = {}) {
+    if (!frame) return;
+    const Cesium = this.Cesium;
+    const origin = new Cesium.Cartesian3(frame.origin.x, frame.origin.y, frame.origin.z);
+    const axes = {
+      x: toCartesian3(Cesium, frame.axes.x),
+      y: toCartesian3(Cesium, frame.axes.y),
+      z: toCartesian3(Cesium, frame.axes.z),
+    };
+    const scaleSize = computeWorldScale(Cesium, this.scene, camera, origin, {
+      ...this.size,
+      ...options,
+    });
+
+    this._updateTranslationAxes(origin, axes, scaleSize);
+    this._updateTranslationPlanes(origin, axes, scaleSize * 0.6);
+    this._updateScaleHandles(origin, axes, scaleSize * 0.8);
+    this._updateRotationRings(origin, axes, scaleSize);
+    this._updateUniformScale(origin);
+  }
+
+  _updateTranslationAxes(origin, axes, length) {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const handle = this.handles.get(`translate-${axis}`);
+      if (!handle) return;
+      const entity = handle.entity;
+      const axisVector = axes[axis];
+      const end = Cesium.Cartesian3.add(
+        origin,
+        Cesium.Cartesian3.multiplyByScalar(axisVector, length, new Cesium.Cartesian3()),
+        new Cesium.Cartesian3()
+      );
+      entity.polyline.positions = [origin, end];
+      entity.point.position = end;
+    });
+  }
+
+  _updateTranslationPlanes(origin, axes, size) {
+    const Cesium = this.Cesium;
+    const combos = {
+      xy: ['x', 'y'],
+      yz: ['y', 'z'],
+      xz: ['x', 'z'],
+    };
+    Object.entries(combos).forEach(([plane, [axisA, axisB]]) => {
+      const handle = this.handles.get(`translate-${plane}`);
+      if (!handle) return;
+      const entity = handle.entity;
+      const a = axes[axisA];
+      const b = axes[axisB];
+      const corners = planeSquare(Cesium, origin, a, b, size);
+      entity.polygon.hierarchy = new Cesium.PolygonHierarchy(corners);
+      entity.polyline.positions = [...corners, corners[0]];
+    });
+  }
+
+  _updateScaleHandles(origin, axes, length) {
+    const Cesium = this.Cesium;
+    ['x', 'y', 'z'].forEach((axis) => {
+      const handle = this.handles.get(`scale-${axis}`);
+      if (!handle) return;
+      const entity = handle.entity;
+      const axisVector = axes[axis];
+      const end = Cesium.Cartesian3.add(
+        origin,
+        Cesium.Cartesian3.multiplyByScalar(axisVector, length, new Cesium.Cartesian3()),
+        new Cesium.Cartesian3()
+      );
+      entity.polyline.positions = [origin, end];
+      entity.billboard.position = end;
+    });
+  }
+
+  _updateRotationRings(origin, axes, radius) {
+    const Cesium = this.Cesium;
+    const segments = 64;
+    const combos = {
+      x: ['y', 'z'],
+      y: ['x', 'z'],
+      z: ['x', 'y'],
+    };
+    Object.entries(combos).forEach(([axis, [a, b]]) => {
+      const handle = this.handles.get(`rotate-${axis}`);
+      if (!handle) return;
+      const positions = unitCirclePoints(Cesium, axes[a], axes[b], origin, radius, segments);
+      handle.entity.polyline.positions = positions;
+    });
+    const viewHandle = this.handles.get('rotate-view');
+    if (viewHandle) {
+      const positions = unitCirclePoints(
+        Cesium,
+        axes.x,
+        axes.y,
+        origin,
+        radius * 1.05,
+        segments
+      );
+      viewHandle.entity.polyline.positions = positions;
+    }
+  }
+
+  _updateUniformScale(origin) {
+    const handle = this.handles.get('scale-uniform');
+    if (!handle) return;
+    handle.entity.point.position = origin;
+  }
+
+  setHover(handleId) {
+    this.hoverHandle = handleId;
+    this._refreshColors();
+  }
+
+  setActive(handleId) {
+    this.activeHandle = handleId;
+    this._refreshColors();
+  }
+
+  _refreshColors() {
+    const Cesium = this.Cesium;
+    this.handles.forEach((handle, id) => {
+      const entity = handle.entity;
+      const axis = handle.axis ?? 'view';
+      const palette = this.colors[axis] ?? this.colors.view;
+      let colorArray = palette.inactive;
+      if (this.activeHandle === id) {
+        colorArray = palette.active ?? palette.hover ?? palette.inactive;
+      } else if (this.hoverHandle === id) {
+        colorArray = palette.hover ?? palette.inactive;
+      }
+      const color = colorFromArray(Cesium, colorArray);
+      if (entity.polyline) {
+        entity.polyline.material = color;
+      }
+      if (entity.point) {
+        entity.point.color = color;
+      }
+      if (entity.billboard) {
+        entity.billboard.color = color;
+      }
+      if (entity.polygon) {
+        entity.polygon.material = color.withAlpha(0.2);
+      }
+    });
+  }
+
+  destroy() {
+    this.entities.forEach((entity) => {
+      this.viewer.entities.remove(entity);
+    });
+    this.entities.length = 0;
+    this.handles.clear();
+  }
+}

--- a/src/HudOverlay.js
+++ b/src/HudOverlay.js
@@ -1,0 +1,61 @@
+export class HudOverlay {
+  constructor({ container = null } = {}) {
+    if (typeof document === 'undefined') {
+      this.enabled = false;
+      return;
+    }
+    this.enabled = true;
+    this.container = container ?? document.body;
+    this.root = document.createElement('div');
+    this.root.className = 'universal-manipulator-hud';
+    Object.assign(this.root.style, {
+      position: 'absolute',
+      top: '12px',
+      right: '12px',
+      padding: '8px 12px',
+      borderRadius: '6px',
+      background: 'rgba(0,0,0,0.6)',
+      color: '#fff',
+      fontFamily: 'sans-serif',
+      fontSize: '12px',
+      pointerEvents: 'none',
+      minWidth: '160px',
+      display: 'none',
+      zIndex: 1000,
+    });
+    this.titleEl = document.createElement('div');
+    this.valueEl = document.createElement('div');
+    this.root.appendChild(this.titleEl);
+    this.root.appendChild(this.valueEl);
+    this.container.appendChild(this.root);
+  }
+
+  setVisible(visible) {
+    if (!this.enabled) return;
+    this.root.style.display = visible ? 'block' : 'none';
+  }
+
+  update({ mode, axis, plane, values }) {
+    if (!this.enabled) return;
+    this.titleEl.textContent = `${mode.toUpperCase()} ${axis ?? plane ?? ''}`.trim();
+    if (!values) {
+      this.valueEl.textContent = '';
+      return;
+    }
+    if (typeof values === 'number') {
+      this.valueEl.textContent = values.toFixed(3);
+      return;
+    }
+    if (Array.isArray(values)) {
+      this.valueEl.textContent = values.map((v) => v.toFixed(3)).join(' , ');
+      return;
+    }
+    const parts = Object.entries(values).map(([key, value]) => `${key}: ${Number(value).toFixed(3)}`);
+    this.valueEl.textContent = parts.join('  ');
+  }
+
+  destroy() {
+    if (!this.enabled) return;
+    this.root.remove();
+  }
+}

--- a/src/ManipulatorController.js
+++ b/src/ManipulatorController.js
@@ -1,0 +1,458 @@
+import {
+  beginAxisTranslation,
+  updateAxisTranslation,
+  beginPlaneTranslation,
+  updatePlaneTranslation,
+  beginAxisRotation,
+  updateAxisRotation,
+  beginViewRotation,
+  beginAxisScale,
+  updateAxisScale,
+  beginUniformScale,
+  updateUniformScale,
+} from './TransformSolver.js';
+import { Snapper } from './Snapper.js';
+import { PivotResolver } from './PivotResolver.js';
+import { FrameBuilder } from './FrameBuilder.js';
+import {
+  add,
+  composeTransform,
+  decomposeTransform,
+  projectOnVector,
+  rotateVectorByQuaternion,
+  scale as scaleVector,
+  subtract,
+  ZERO_VECTOR,
+  quaternionMultiply,
+} from './math.js';
+import { HudOverlay } from './HudOverlay.js';
+
+function cartesianToVector(cart) {
+  if (!cart) return ZERO_VECTOR;
+  return { x: cart.x, y: cart.y, z: cart.z };
+}
+
+function rayToSimple(ray) {
+  return {
+    origin: cartesianToVector(ray.origin),
+    direction: cartesianToVector(ray.direction),
+  };
+}
+
+function cloneMatrix(matrix) {
+  return matrix.slice();
+}
+
+function getTargetMatrix(target, Cesium) {
+  if (!target) return null;
+  if (target.matrix) {
+    return target.matrix.slice();
+  }
+  if (target.modelMatrix) {
+    return target.modelMatrix.slice();
+  }
+  if (typeof target.getWorldMatrix === 'function') {
+    return cloneMatrix(target.getWorldMatrix());
+  }
+  if (target.entity && typeof target.entity.computeModelMatrix === 'function') {
+    const time = Cesium?.JulianDate?.now ? Cesium.JulianDate.now() : undefined;
+    return cloneMatrix(target.entity.computeModelMatrix(time));
+  }
+  return null;
+}
+
+function setTargetMatrix(target, matrix, Cesium) {
+  if (target.matrix) {
+    target.matrix = matrix.slice();
+    return;
+  }
+  if (target.modelMatrix) {
+    target.modelMatrix = matrix.slice();
+    return;
+  }
+  if (typeof target.setMatrix === 'function') {
+    target.setMatrix(matrix);
+    return;
+  }
+  if (target.entity) {
+    const translation = { x: matrix[3], y: matrix[7], z: matrix[11] };
+    const rotationMatrix = [
+      matrix[0], matrix[1], matrix[2],
+      matrix[4], matrix[5], matrix[6],
+      matrix[8], matrix[9], matrix[10],
+    ];
+    const scale = {
+      x: Math.hypot(matrix[0], matrix[4], matrix[8]),
+      y: Math.hypot(matrix[1], matrix[5], matrix[9]),
+      z: Math.hypot(matrix[2], matrix[6], matrix[10]),
+    };
+    if (Cesium && target.entity.position) {
+      target.entity.position = new Cesium.ConstantPositionProperty(
+        new Cesium.Cartesian3(translation.x, translation.y, translation.z)
+      );
+    }
+    if (Cesium && target.entity.orientation) {
+      const quaternion = Cesium.Quaternion.fromRotationMatrix(
+        Cesium.Matrix3.fromArray(rotationMatrix)
+      );
+      target.entity.orientation = new Cesium.ConstantProperty(quaternion);
+    }
+    if (target.entity.model) {
+      target.entity.model.scale = (scale.x + scale.y + scale.z) / 3;
+    }
+  }
+}
+
+export class ManipulatorController {
+  constructor({ Cesium, viewer, gizmo, picker, frameBuilder, snapper, pivotResolver, hud }) {
+    this.Cesium = Cesium;
+    this.viewer = viewer;
+    this.scene = viewer.scene;
+    this.gizmo = gizmo;
+    this.picker = picker;
+    this.frameBuilder = frameBuilder ?? new FrameBuilder({ Cesium });
+    this.snapper = snapper ?? new Snapper();
+    this.pivotResolver = pivotResolver ?? new PivotResolver();
+    this.hud = hud ?? new HudOverlay({ container: viewer.container });
+    this.mode = 'translate';
+    this.orientation = 'global';
+    this.targets = [];
+    this.state = 'idle';
+    this.currentHandle = null;
+    this.dragSession = null;
+    this.frame = null;
+    this.pivotData = null;
+    this.clock = viewer.clock;
+    this._keyState = { ctrlKey: false, shiftKey: false, altKey: false };
+    this._registerKeyEvents();
+    this._createHandler();
+  }
+
+  _registerKeyEvents() {
+    if (typeof document === 'undefined') return;
+    this._keyDownListener = (event) => {
+      this._keyState = {
+        ctrlKey: event.ctrlKey || event.metaKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+      };
+    };
+    this._keyUpListener = (event) => {
+      this._keyState = {
+        ctrlKey: event.ctrlKey || event.metaKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+      };
+    };
+    document.addEventListener('keydown', this._keyDownListener);
+    document.addEventListener('keyup', this._keyUpListener);
+  }
+
+  _createHandler() {
+    const Cesium = this.Cesium;
+    this.handler = new Cesium.ScreenSpaceEventHandler(this.scene.canvas);
+    this.handler.setInputAction((movement) => {
+      this._onPointerMove(movement.endPosition ?? movement.position);
+    }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+    this.handler.setInputAction((movement) => {
+      this._onPointerDown(movement.position);
+    }, Cesium.ScreenSpaceEventType.LEFT_DOWN);
+    this.handler.setInputAction((movement) => {
+      this._onPointerUp(movement.position);
+    }, Cesium.ScreenSpaceEventType.LEFT_UP);
+    this.handler.setInputAction(() => {
+      this._cancelDrag();
+    }, Cesium.ScreenSpaceEventType.RIGHT_DOWN);
+  }
+
+  setMode(mode) {
+    this.mode = mode;
+    this.gizmo.setMode(mode);
+  }
+
+  setOrientation(orientation) {
+    this.orientation = orientation;
+    this._updateFrame();
+  }
+
+  setPivot(pivot) {
+    this.pivotResolver.setMode(pivot);
+    this._updateFrame();
+  }
+
+  setTargets(targets) {
+    this.targets = Array.isArray(targets) ? targets : targets ? [targets] : [];
+    this._updateFrame();
+  }
+
+  setSnap(config) {
+    this.snapper.setConfig(config);
+  }
+
+  enableHud(show) {
+    this.hud.setVisible(show);
+  }
+
+  _updateFrame() {
+    if (!this.targets.length) return;
+    const primary = this.targets[0];
+    this.frame = this.frameBuilder.buildFrame({
+      target: primary,
+      orientation: this.orientation,
+      camera: this.scene.camera,
+    });
+    this.gizmo.update(this.frame, this.scene.camera);
+  }
+
+  _onPointerMove(position) {
+    if (!position) return;
+    if (this.state === 'dragging') {
+      this._updateDrag(position);
+      return;
+    }
+    const handle = this.picker.pick(position);
+    if (handle) {
+      this.gizmo.setHover(handle.id);
+    } else {
+      this.gizmo.setHover(null);
+    }
+  }
+
+  _onPointerDown(position) {
+    if (!position) return;
+    const handle = this.picker.drillPick(position);
+    if (!handle) return;
+    this.currentHandle = handle;
+    this.gizmo.setActive(handle.id);
+    this.state = 'dragging';
+    this.hud.setVisible(true);
+    this._beginDrag(position, handle);
+  }
+
+  _beginDrag(position, handle) {
+    const camera = this.scene.camera;
+    const ray = camera.getPickRay(position);
+    if (!ray) return;
+    this._updateFrame();
+    const simpleRay = rayToSimple(ray);
+    const cameraDirection = cartesianToVector(camera.direction);
+    const pivot = this.pivotResolver.resolve(this.targets);
+    this.pivotData = pivot;
+    const startTransforms = this.targets.map((target) => {
+      const matrix = getTargetMatrix(target, this.Cesium);
+      const transform = decomposeTransform(matrix);
+      return { target, matrix, transform };
+    });
+    this.dragSession = {
+      handle,
+      startRay: simpleRay,
+      startTransforms,
+      pivot,
+    };
+
+    switch (handle.type) {
+      case 'translate-axis':
+        this.dragSession.operation = beginAxisTranslation({
+          axis: this.frame.axes[handle.axis],
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+          cameraDirection,
+        });
+        break;
+      case 'translate-plane':
+        this.dragSession.operation = beginPlaneTranslation({
+          planeNormal: this._planeNormalForHandle(handle),
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+        });
+        break;
+      case 'rotate-axis':
+        this.dragSession.operation = beginAxisRotation({
+          axis: this.frame.axes[handle.axis],
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+        });
+        break;
+      case 'rotate-view':
+        this.dragSession.operation = beginViewRotation({
+          viewDirection: cameraDirection,
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+        });
+        break;
+      case 'scale-axis':
+        this.dragSession.operation = beginAxisScale({
+          axis: this.frame.axes[handle.axis],
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+          cameraDirection,
+        });
+        break;
+      case 'scale-uniform':
+        this.dragSession.operation = beginUniformScale({
+          pivot: pivot.pivot,
+          startRay: simpleRay,
+          cameraDirection,
+        });
+        break;
+      default:
+        break;
+    }
+  }
+
+  _updateDrag(position) {
+    if (!this.dragSession) return;
+    const camera = this.scene.camera;
+    const ray = camera.getPickRay(position);
+    if (!ray) return;
+    const simpleRay = rayToSimple(ray);
+    const modifiers = this._keyState;
+    const handle = this.dragSession.handle;
+    let delta;
+    switch (handle.type) {
+      case 'translate-axis': {
+        delta = updateAxisTranslation(this.dragSession.operation, simpleRay);
+        const snapped = this.snapper.snapTranslation(delta.distance, modifiers);
+        delta.vector = scaleVector(this.frame.axes[handle.axis], snapped);
+        this._applyTranslation(delta.vector);
+        this.hud.update({ mode: 'translate', axis: handle.axis, values: { [handle.axis]: snapped } });
+        break;
+      }
+      case 'translate-plane': {
+        delta = updatePlaneTranslation(this.dragSession.operation, simpleRay);
+        this._applyTranslation(delta.vector);
+        this.hud.update({ mode: 'translate', plane: handle.plane, values: delta.vector });
+        break;
+      }
+      case 'rotate-axis': {
+        delta = updateAxisRotation(this.dragSession.operation, simpleRay);
+        const angle = this.snapper.snapRotation(delta.angle, modifiers);
+        this._applyRotation(this.frame.axes[handle.axis], angle);
+        this.hud.update({ mode: 'rotate', axis: handle.axis, values: angle });
+        break;
+      }
+      case 'rotate-view': {
+        delta = updateAxisRotation(this.dragSession.operation, simpleRay);
+        const angle = this.snapper.snapRotation(delta.angle, modifiers);
+        this._applyRotation(cartesianToVector(camera.direction), angle);
+        this.hud.update({ mode: 'rotate', axis: 'view', values: angle });
+        break;
+      }
+      case 'scale-axis': {
+        delta = updateAxisScale(this.dragSession.operation, simpleRay);
+        const factor = this.snapper.snapScale(delta.scale, modifiers);
+        this._applyAxisScale(handle.axis, factor);
+        this.hud.update({ mode: 'scale', axis: handle.axis, values: factor });
+        break;
+      }
+      case 'scale-uniform': {
+        delta = updateUniformScale(this.dragSession.operation, simpleRay);
+        const factor = this.snapper.snapScale(delta.scale, modifiers);
+        this._applyUniformScale(factor);
+        this.hud.update({ mode: 'scale', axis: 'uniform', values: factor });
+        break;
+      }
+      default:
+        break;
+    }
+    this._updateFrame();
+  }
+
+  _applyTranslation(vector) {
+    this.dragSession.startTransforms.forEach((entry) => {
+      const translation = add(entry.transform.translation, vector);
+      const matrix = composeTransform(translation, entry.transform.rotation, entry.transform.scale);
+      setTargetMatrix(entry.target, matrix, this.Cesium);
+    });
+  }
+
+  _applyRotation(axisVector, angle) {
+    const rotationQuaternion = {
+      x: axisVector.x * Math.sin(angle / 2),
+      y: axisVector.y * Math.sin(angle / 2),
+      z: axisVector.z * Math.sin(angle / 2),
+      w: Math.cos(angle / 2),
+    };
+    this.dragSession.startTransforms.forEach((entry) => {
+      const pivot = this.pivotData.perTarget.get(entry.target) ?? this.pivotData.pivot;
+      const relative = subtract(entry.transform.translation, pivot);
+      const rotated = rotateVectorByQuaternion(relative, rotationQuaternion);
+      const translation = add(pivot, rotated);
+      const rotation = quaternionMultiply(rotationQuaternion, entry.transform.rotation);
+      const matrix = composeTransform(translation, rotation, entry.transform.scale);
+      setTargetMatrix(entry.target, matrix, this.Cesium);
+    });
+  }
+
+  _applyAxisScale(axis, factor) {
+    const axisVector = this.frame.axes[axis];
+    this.dragSession.startTransforms.forEach((entry) => {
+      const pivot = this.pivotData.perTarget.get(entry.target) ?? this.pivotData.pivot;
+      const relative = subtract(entry.transform.translation, pivot);
+      const along = projectOnVector(relative, axisVector);
+      const perpendicular = subtract(relative, along);
+      const scaledAlong = scaleVector(along, factor);
+      const translation = add(pivot, add(perpendicular, scaledAlong));
+      const scale = {
+        x: entry.transform.scale.x * (axis === 'x' ? factor : 1),
+        y: entry.transform.scale.y * (axis === 'y' ? factor : 1),
+        z: entry.transform.scale.z * (axis === 'z' ? factor : 1),
+      };
+      const matrix = composeTransform(translation, entry.transform.rotation, scale);
+      setTargetMatrix(entry.target, matrix, this.Cesium);
+    });
+  }
+
+  _applyUniformScale(factor) {
+    this.dragSession.startTransforms.forEach((entry) => {
+      const pivot = this.pivotData.perTarget.get(entry.target) ?? this.pivotData.pivot;
+      const relative = subtract(entry.transform.translation, pivot);
+      const translation = add(pivot, scaleVector(relative, factor));
+      const scale = {
+        x: entry.transform.scale.x * factor,
+        y: entry.transform.scale.y * factor,
+        z: entry.transform.scale.z * factor,
+      };
+      const matrix = composeTransform(translation, entry.transform.rotation, scale);
+      setTargetMatrix(entry.target, matrix, this.Cesium);
+    });
+  }
+
+  _planeNormalForHandle(handle) {
+    switch (handle.plane) {
+      case 'xy':
+        return this.frame.axes.z;
+      case 'yz':
+        return this.frame.axes.x;
+      case 'xz':
+        return this.frame.axes.y;
+      default:
+        return this.frame.axes.z;
+    }
+  }
+
+  _onPointerUp() {
+    if (this.state === 'dragging') {
+      this.state = 'idle';
+      this.gizmo.setActive(null);
+      this.hud.setVisible(false);
+      this.dragSession = null;
+    }
+  }
+
+  _cancelDrag() {
+    this.state = 'idle';
+    this.gizmo.setActive(null);
+    this.hud.setVisible(false);
+    this.dragSession = null;
+  }
+
+  destroy() {
+    this.handler?.destroy();
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('keydown', this._keyDownListener);
+      document.removeEventListener('keyup', this._keyUpListener);
+    }
+    this.hud.destroy();
+  }
+}

--- a/src/PivotResolver.js
+++ b/src/PivotResolver.js
@@ -1,0 +1,76 @@
+import { add, scale, ZERO_VECTOR } from './math.js';
+
+function extractTranslation(target) {
+  if (!target) return ZERO_VECTOR;
+  if (target.position) {
+    return target.position;
+  }
+  if (target.matrix) {
+    const m = target.matrix;
+    return { x: m[3], y: m[7], z: m[11] };
+  }
+  if (typeof target.getWorldMatrix === 'function') {
+    const m = target.getWorldMatrix();
+    return { x: m[3], y: m[7], z: m[11] };
+  }
+  return ZERO_VECTOR;
+}
+
+function averagePoints(points) {
+  if (!points.length) return ZERO_VECTOR;
+  const total = points.reduce((acc, point) => add(acc, point), ZERO_VECTOR);
+  return scale(total, 1 / points.length);
+}
+
+export class PivotResolver {
+  constructor() {
+    this.mode = 'origin';
+    this.cursor = ZERO_VECTOR;
+  }
+
+  setMode(mode) {
+    this.mode = mode;
+  }
+
+  setCursor(position) {
+    this.cursor = position;
+  }
+
+  resolve(targets, modeOverride) {
+    const mode = modeOverride ?? this.mode;
+    const targetArray = Array.isArray(targets) ? targets : [targets];
+    const positions = targetArray.map(extractTranslation);
+    if (!targetArray.length) {
+      return { pivot: ZERO_VECTOR, perTarget: new Map() };
+    }
+
+    if (mode === 'cursor') {
+      const map = new Map();
+      for (const target of targetArray) {
+        map.set(target, this.cursor);
+      }
+      return { pivot: this.cursor, perTarget: map };
+    }
+
+    if (mode === 'individual') {
+      const map = new Map();
+      targetArray.forEach((target, index) => {
+        map.set(target, positions[index]);
+      });
+      return { pivot: positions[0], perTarget: map };
+    }
+
+    if (mode === 'median') {
+      const pivot = averagePoints(positions);
+      const map = new Map();
+      targetArray.forEach((target) => map.set(target, pivot));
+      return { pivot, perTarget: map };
+    }
+
+    // origin fallback
+    const pivot = positions[0];
+    const map = new Map();
+    targetArray.forEach((target) => map.set(target, pivot));
+    return { pivot, perTarget: map };
+  }
+}

--- a/src/Snapper.js
+++ b/src/Snapper.js
@@ -1,0 +1,45 @@
+const DEFAULTS = {
+  translate: 1.0,
+  rotate: (5 * Math.PI) / 180,
+  scale: 0.1,
+};
+
+function resolveStep(base, modifiers) {
+  if (!base || base <= 0) return 0;
+  let step = base;
+  if (modifiers?.shiftKey) {
+    step *= 0.1;
+  }
+  if (modifiers?.altKey) {
+    step *= 0.25;
+  }
+  return step;
+}
+
+export class Snapper {
+  constructor(config = {}) {
+    this.steps = { ...DEFAULTS, ...config };
+  }
+
+  setConfig(config) {
+    this.steps = { ...this.steps, ...config };
+  }
+
+  snapTranslation(value, modifiers = {}) {
+    const step = resolveStep(this.steps.translate, modifiers);
+    if (!step || !modifiers?.ctrlKey) return value;
+    return Math.round(value / step) * step;
+  }
+
+  snapRotation(angle, modifiers = {}) {
+    const step = resolveStep(this.steps.rotate, modifiers);
+    if (!step || !modifiers?.ctrlKey) return angle;
+    return Math.round(angle / step) * step;
+  }
+
+  snapScale(scale, modifiers = {}) {
+    const step = resolveStep(this.steps.scale, modifiers);
+    if (!step || !modifiers?.ctrlKey) return scale;
+    return Math.round((scale - 1) / step) * step + 1;
+  }
+}

--- a/src/TransformSolver.js
+++ b/src/TransformSolver.js
@@ -1,0 +1,185 @@
+import {
+  add,
+  angleBetween,
+  clampMagnitude,
+  cross,
+  magnitude,
+  normalize,
+  projectScalar,
+  rayPlaneIntersection,
+  scale,
+  subtract,
+  ZERO_VECTOR,
+  fromAxisAngle,
+  quaternionMultiply,
+  IDENTITY_QUATERNION,
+} from './math.js';
+
+const EPSILON = 1e-6;
+
+function ensurePlaneNormal(axis, cameraDirection) {
+  let planeNormal = cross(axis, cameraDirection);
+  if (magnitude(planeNormal) < EPSILON) {
+    const fallback = Math.abs(axis.z) < 0.9 ? { x: 0, y: 0, z: 1 } : { x: 0, y: 1, z: 0 };
+    planeNormal = cross(axis, fallback);
+  }
+  const normal = cross(axis, planeNormal);
+  if (magnitude(normal) < EPSILON) {
+    return normalize(planeNormal);
+  }
+  return normalize(normal);
+}
+
+export function beginAxisTranslation({ axis, pivot, startRay, cameraDirection }) {
+  const axisNorm = normalize(axis);
+  const planeNormal = ensurePlaneNormal(axisNorm, normalize(cameraDirection));
+  const startPoint =
+    rayPlaneIntersection(startRay, planeNormal, pivot) ?? add(pivot, scale(axisNorm, 0));
+  return {
+    type: 'axis-translate',
+    axis: axisNorm,
+    pivot,
+    planeNormal,
+    startPoint,
+  };
+}
+
+export function updateAxisTranslation(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.planeNormal, session.pivot);
+  if (!point) {
+    return { distance: 0, vector: ZERO_VECTOR };
+  }
+  const deltaVector = subtract(point, session.startPoint);
+  const distance = projectScalar(deltaVector, session.axis);
+  const vector = scale(session.axis, distance);
+  return { distance, vector };
+}
+
+export function beginPlaneTranslation({ planeNormal, pivot, startRay }) {
+  const normal = normalize(planeNormal);
+  const startPoint = rayPlaneIntersection(startRay, normal, pivot) ?? pivot;
+  return {
+    type: 'plane-translate',
+    normal,
+    pivot,
+    startPoint,
+  };
+}
+
+export function updatePlaneTranslation(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.normal, session.pivot);
+  if (!point) {
+    return { vector: ZERO_VECTOR };
+  }
+  const vector = subtract(point, session.startPoint);
+  return { vector };
+}
+
+export function beginAxisRotation({ axis, pivot, startRay }) {
+  const normal = normalize(axis);
+  const startPoint = rayPlaneIntersection(startRay, normal, pivot);
+  const startVector = startPoint ? subtract(startPoint, pivot) : ZERO_VECTOR;
+  return {
+    type: 'axis-rotate',
+    axis: normal,
+    pivot,
+    startVector: startVector,
+    lastAngle: 0,
+  };
+}
+
+export function updateAxisRotation(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.axis, session.pivot);
+  if (!point) {
+    return { angle: 0, quaternion: IDENTITY_QUATERNION };
+  }
+  const vector = subtract(point, session.pivot);
+  if (magnitude(vector) < EPSILON || magnitude(session.startVector) < EPSILON) {
+    return { angle: 0, quaternion: IDENTITY_QUATERNION };
+  }
+  const angle = angleBetween(session.startVector, vector, session.axis);
+  session.lastAngle = angle;
+  const quaternion = fromAxisAngle(session.axis, angle);
+  return { angle, quaternion };
+}
+
+export function beginViewRotation({ viewDirection, pivot, startRay }) {
+  const axis = normalize(viewDirection);
+  return beginAxisRotation({ axis, pivot, startRay });
+}
+
+export function beginAxisScale({ axis, pivot, startRay, cameraDirection }) {
+  const axisNorm = normalize(axis);
+  const planeNormal = ensurePlaneNormal(axisNorm, cameraDirection);
+  const startPoint = rayPlaneIntersection(startRay, planeNormal, pivot) ?? pivot;
+  const referenceVector = subtract(startPoint, pivot);
+  const initialLength = Math.max(Math.abs(projectScalar(referenceVector, axisNorm)), EPSILON);
+  return {
+    type: 'axis-scale',
+    axis: axisNorm,
+    pivot,
+    planeNormal,
+    startPoint,
+    initialLength,
+  };
+}
+
+export function updateAxisScale(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.planeNormal, session.pivot);
+  if (!point) {
+    return { scale: 1 };
+  }
+  const deltaVector = subtract(point, session.startPoint);
+  const distance = projectScalar(deltaVector, session.axis);
+  const factor = clampMagnitude(1 + distance / session.initialLength);
+  return { scale: factor === 0 ? 1 : factor, axis: session.axis };
+}
+
+export function beginUniformScale({ pivot, startRay, cameraDirection }) {
+  const normal = normalize(cameraDirection);
+  const startPoint = rayPlaneIntersection(startRay, normal, pivot) ?? pivot;
+  const baseDistance = magnitude(subtract(startPoint, pivot));
+  return {
+    type: 'uniform-scale',
+    pivot,
+    normal,
+    startPoint,
+    baseDistance: Math.max(baseDistance, EPSILON),
+  };
+}
+
+export function updateUniformScale(session, currentRay) {
+  const point = rayPlaneIntersection(currentRay, session.normal, session.pivot);
+  if (!point) {
+    return { scale: 1 };
+  }
+  const distance = magnitude(subtract(point, session.pivot));
+  const factor = clampMagnitude(distance / session.baseDistance);
+  return { scale: factor === 0 ? 1 : factor };
+}
+
+export function accumulateTranslation(delta, current) {
+  return add(current ?? ZERO_VECTOR, delta);
+}
+
+export function accumulateRotation(deltaQuaternion, currentQuaternion) {
+  return quaternionMultiply(deltaQuaternion, currentQuaternion ?? IDENTITY_QUATERNION);
+}
+
+export function accumulateScale(deltaScale, currentScale) {
+  if (!currentScale) {
+    return { x: deltaScale.x ?? deltaScale, y: deltaScale.y ?? deltaScale, z: deltaScale.z ?? deltaScale };
+  }
+  if (typeof deltaScale === 'number') {
+    return {
+      x: currentScale.x * deltaScale,
+      y: currentScale.y * deltaScale,
+      z: currentScale.z * deltaScale,
+    };
+  }
+  return {
+    x: currentScale.x * (deltaScale.x ?? 1),
+    y: currentScale.y * (deltaScale.y ?? 1),
+    z: currentScale.z * (deltaScale.z ?? 1),
+  };
+}

--- a/src/UniversalManipulator.js
+++ b/src/UniversalManipulator.js
@@ -1,0 +1,123 @@
+import { GizmoPrimitive } from './GizmoPrimitive.js';
+import { GizmoPicker } from './GizmoPicker.js';
+import { ManipulatorController } from './ManipulatorController.js';
+import { FrameBuilder } from './FrameBuilder.js';
+import { Snapper } from './Snapper.js';
+import { PivotResolver } from './PivotResolver.js';
+import { HudOverlay } from './HudOverlay.js';
+
+export class UniversalManipulator {
+  constructor(options = {}) {
+    const {
+      Cesium,
+      viewer,
+      target = null,
+      mode = 'translate',
+      orientation = 'global',
+      pivot = 'origin',
+      snap = {},
+      size = {},
+      hudContainer = null,
+    } = options;
+
+    if (!Cesium) {
+      throw new Error('Cesium namespace must be provided to UniversalManipulator.');
+    }
+    if (!viewer) {
+      throw new Error('viewer is required to create UniversalManipulator.');
+    }
+
+    this.Cesium = Cesium;
+    this.viewer = viewer;
+    this.enabledModes = { translate: true, rotate: true, scale: true };
+
+    this.gizmo = new GizmoPrimitive({ Cesium, viewer, size });
+    this.picker = new GizmoPicker(viewer.scene, this.gizmo);
+    this.frameBuilder = new FrameBuilder({ Cesium });
+    this.snapper = new Snapper(snap);
+    this.pivotResolver = new PivotResolver();
+    this.hud = new HudOverlay({ container: hudContainer ?? (typeof viewer.container !== 'string' ? viewer.container : null) });
+
+    this.controller = new ManipulatorController({
+      Cesium,
+      viewer,
+      gizmo: this.gizmo,
+      picker: this.picker,
+      frameBuilder: this.frameBuilder,
+      snapper: this.snapper,
+      pivotResolver: this.pivotResolver,
+      hud: this.hud,
+    });
+
+    this._show = true;
+    this.setMode(mode);
+    this.setOrientation(orientation);
+    this.setPivot(pivot);
+    this.setSnap(snap);
+    if (target) {
+      this.setTarget(target);
+    }
+  }
+
+  get show() {
+    return this._show;
+  }
+
+  set show(value) {
+    this._show = Boolean(value);
+    this.gizmo.setShow(this._show);
+  }
+
+  setTarget(target) {
+    this.controller.setTargets(target);
+  }
+
+  setOrientation(orientation) {
+    this.controller.setOrientation(orientation);
+  }
+
+  setPivot(pivot) {
+    this.controller.setPivot(pivot);
+  }
+
+  setCursor(position) {
+    this.pivotResolver.setCursor(position);
+  }
+
+  setMode(mode) {
+    if (this.enabledModes && this.enabledModes[mode] === false) {
+      throw new Error(`Mode ${mode} is disabled.`);
+    }
+    this.mode = mode;
+    this.controller.setMode(mode);
+    this.gizmo.setMode(mode);
+  }
+
+  enable(config) {
+    this.enabledModes = { ...this.enabledModes, ...config };
+    if (this.mode && this.enabledModes[this.mode] === false) {
+      const fallback = Object.keys(this.enabledModes).find((key) => this.enabledModes[key]);
+      if (fallback) {
+        this.setMode(fallback);
+      }
+    }
+  }
+
+  setSnap(stepConfig) {
+    this.snapper.setConfig(stepConfig);
+  }
+
+  setSize(screenPixelRadius, minScale, maxScale) {
+    const updated = { ...this.gizmo.size };
+    if (screenPixelRadius !== undefined) updated.screenRadius = screenPixelRadius;
+    if (minScale !== undefined) updated.minScale = minScale;
+    if (maxScale !== undefined) updated.maxScale = maxScale;
+    this.gizmo.size = updated;
+  }
+
+  destroy() {
+    this.controller.destroy();
+    this.gizmo.destroy();
+    this.hud.destroy();
+  }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,45 @@
+export const AXIS_COLORS = {
+  x: { inactive: [1, 0.266, 0.266, 1], hover: [1, 0.5, 0.5, 1], active: [1, 0.8, 0.6, 1] },
+  y: { inactive: [0.266, 1, 0.266, 1], hover: [0.5, 1, 0.5, 1], active: [0.6, 1, 0.8, 1] },
+  z: { inactive: [0.266, 0.6, 1, 1], hover: [0.5, 0.7, 1, 1], active: [0.6, 0.85, 1, 1] },
+  view: { inactive: [1, 1, 1, 1], hover: [1, 1, 1, 1], active: [1, 1, 1, 1] },
+};
+
+export const HANDLE_TYPES = {
+  TRANSLATE_AXIS: 'translate-axis',
+  TRANSLATE_PLANE: 'translate-plane',
+  ROTATE_AXIS: 'rotate-axis',
+  ROTATE_VIEW: 'rotate-view',
+  SCALE_AXIS: 'scale-axis',
+  SCALE_UNIFORM: 'scale-uniform',
+};
+
+export const MODE_HANDLES = {
+  translate: ['x', 'y', 'z', 'xy', 'yz', 'xz'],
+  rotate: ['x', 'y', 'z', 'view'],
+  scale: ['x', 'y', 'z', 'uniform'],
+};
+
+export const AXIS_VECTORS = {
+  x: { x: 1, y: 0, z: 0 },
+  y: { x: 0, y: 1, z: 0 },
+  z: { x: 0, y: 0, z: 1 },
+};
+
+export const PLANE_NORMALS = {
+  xy: { x: 0, y: 0, z: 1 },
+  yz: { x: 1, y: 0, z: 0 },
+  xz: { x: 0, y: 1, z: 0 },
+};
+
+export const DEFAULT_SIZE = {
+  screenRadius: 110,
+  minScale: 0.2,
+  maxScale: 2.5,
+};
+
+export const MODE_TO_HANDLE_TYPE = {
+  translate: HANDLE_TYPES.TRANSLATE_AXIS,
+  rotate: HANDLE_TYPES.ROTATE_AXIS,
+  scale: HANDLE_TYPES.SCALE_AXIS,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,9 @@
+export { UniversalManipulator } from './UniversalManipulator.js';
+export { GizmoPrimitive } from './GizmoPrimitive.js';
+export { GizmoPicker } from './GizmoPicker.js';
+export { ManipulatorController } from './ManipulatorController.js';
+export { FrameBuilder } from './FrameBuilder.js';
+export { PivotResolver } from './PivotResolver.js';
+export { Snapper } from './Snapper.js';
+export * as math from './math.js';
+export * as TransformSolver from './TransformSolver.js';

--- a/src/math.js
+++ b/src/math.js
@@ -1,0 +1,300 @@
+const EPSILON = 1e-10;
+
+export function clone(v) {
+  return { x: v.x, y: v.y, z: v.z };
+}
+
+export function add(a, b) {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+export function subtract(a, b) {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+export function scale(v, scalar) {
+  return { x: v.x * scalar, y: v.y * scalar, z: v.z * scalar };
+}
+
+export function dot(a, b) {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+export function cross(a, b) {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+export function magnitude(v) {
+  return Math.sqrt(dot(v, v));
+}
+
+export function normalize(v) {
+  const mag = magnitude(v);
+  if (mag < EPSILON) {
+    return { x: 0, y: 0, z: 0 };
+  }
+  return scale(v, 1 / mag);
+}
+
+export function equalsEpsilon(a, b, epsilon = EPSILON) {
+  return (
+    Math.abs(a.x - b.x) <= epsilon &&
+    Math.abs(a.y - b.y) <= epsilon &&
+    Math.abs(a.z - b.z) <= epsilon
+  );
+}
+
+export function equalsQuaternion(a, b, epsilon = EPSILON) {
+  if (!a || !b) return false;
+  const diff = Math.abs(a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w);
+  return Math.abs(1 - diff) <= epsilon;
+}
+
+export function fromAxisAngle(axis, angle) {
+  const half = angle * 0.5;
+  const s = Math.sin(half);
+  const norm = normalize(axis);
+  return {
+    x: norm.x * s,
+    y: norm.y * s,
+    z: norm.z * s,
+    w: Math.cos(half),
+  };
+}
+
+export function quaternionMultiply(a, b) {
+  return {
+    w: a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z,
+    x: a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+    y: a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+    z: a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
+  };
+}
+
+export function rotateVectorByQuaternion(vector, quaternion) {
+  const qVec = { x: quaternion.x, y: quaternion.y, z: quaternion.z };
+  const uv = cross(qVec, vector);
+  const uuv = cross(qVec, uv);
+  const uvScaled = scale(uv, 2 * quaternion.w);
+  const uuvScaled = scale(uuv, 2);
+  return add(vector, add(uvScaled, uuvScaled));
+}
+
+export function quaternionToMatrix(q) {
+  const xx = q.x * q.x;
+  const yy = q.y * q.y;
+  const zz = q.z * q.z;
+  const xy = q.x * q.y;
+  const xz = q.x * q.z;
+  const yz = q.y * q.z;
+  const wx = q.w * q.x;
+  const wy = q.w * q.y;
+  const wz = q.w * q.z;
+
+  return [
+    1 - 2 * (yy + zz), 2 * (xy - wz), 2 * (xz + wy),
+    2 * (xy + wz), 1 - 2 * (xx + zz), 2 * (yz - wx),
+    2 * (xz - wy), 2 * (yz + wx), 1 - 2 * (xx + yy),
+  ];
+}
+
+export function matrixToQuaternion(m) {
+  const trace = m[0] + m[4] + m[8];
+  let q = { x: 0, y: 0, z: 0, w: 1 };
+  if (trace > 0) {
+    const s = Math.sqrt(trace + 1.0) * 2;
+    q.w = 0.25 * s;
+    q.x = (m[7] - m[5]) / s;
+    q.y = (m[2] - m[6]) / s;
+    q.z = (m[3] - m[1]) / s;
+  } else if (m[0] > m[4] && m[0] > m[8]) {
+    const s = Math.sqrt(1.0 + m[0] - m[4] - m[8]) * 2;
+    q.w = (m[7] - m[5]) / s;
+    q.x = 0.25 * s;
+    q.y = (m[1] + m[3]) / s;
+    q.z = (m[2] + m[6]) / s;
+  } else if (m[4] > m[8]) {
+    const s = Math.sqrt(1.0 + m[4] - m[0] - m[8]) * 2;
+    q.w = (m[2] - m[6]) / s;
+    q.x = (m[1] + m[3]) / s;
+    q.y = 0.25 * s;
+    q.z = (m[5] + m[7]) / s;
+  } else {
+    const s = Math.sqrt(1.0 + m[8] - m[0] - m[4]) * 2;
+    q.w = (m[3] - m[1]) / s;
+    q.x = (m[2] + m[6]) / s;
+    q.y = (m[5] + m[7]) / s;
+    q.z = 0.25 * s;
+  }
+  return normalizeQuaternion(q);
+}
+
+export function normalizeQuaternion(q) {
+  const len = Math.sqrt(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
+  if (len < EPSILON) {
+    return { x: 0, y: 0, z: 0, w: 1 };
+  }
+  return { x: q.x / len, y: q.y / len, z: q.z / len, w: q.w / len };
+}
+
+export function composeTransform(translation, rotation, scaleVec) {
+  const m = quaternionToMatrix(rotation);
+  return [
+    m[0] * scaleVec.x, m[1] * scaleVec.y, m[2] * scaleVec.z, 0,
+    m[3] * scaleVec.x, m[4] * scaleVec.y, m[5] * scaleVec.z, 0,
+    m[6] * scaleVec.x, m[7] * scaleVec.y, m[8] * scaleVec.z, 0,
+    translation.x, translation.y, translation.z, 1,
+  ];
+}
+
+export function decomposeTransform(matrix) {
+  const translation = { x: matrix[12], y: matrix[13], z: matrix[14] };
+  const basisX = { x: matrix[0], y: matrix[4], z: matrix[8] };
+  const basisY = { x: matrix[1], y: matrix[5], z: matrix[9] };
+  const basisZ = { x: matrix[2], y: matrix[6], z: matrix[10] };
+  const scale = {
+    x: magnitude(basisX),
+    y: magnitude(basisY),
+    z: magnitude(basisZ),
+  };
+  const invScale = {
+    x: scale.x > EPSILON ? 1 / scale.x : 0,
+    y: scale.y > EPSILON ? 1 / scale.y : 0,
+    z: scale.z > EPSILON ? 1 / scale.z : 0,
+  };
+  const rotMatrix = [
+    basisX.x * invScale.x, basisY.x * invScale.y, basisZ.x * invScale.z,
+    basisX.y * invScale.x, basisY.y * invScale.y, basisZ.y * invScale.z,
+    basisX.z * invScale.x, basisY.z * invScale.y, basisZ.z * invScale.z,
+  ];
+  const rotation = matrixToQuaternion(rotMatrix);
+  return { translation, rotation, scale };
+}
+
+export function projectOnVector(vector, axis) {
+  const axisNorm = normalize(axis);
+  return scale(axisNorm, dot(vector, axisNorm));
+}
+
+export function projectScalar(vector, axis) {
+  const axisNorm = normalize(axis);
+  return dot(vector, axisNorm);
+}
+
+export function angleBetween(a, b, normal) {
+  const aNorm = normalize(a);
+  const bNorm = normalize(b);
+  const crossProd = cross(aNorm, bNorm);
+  const sin = magnitude(crossProd);
+  const cos = dot(aNorm, bNorm);
+  let angle = Math.atan2(sin, cos);
+  if (normal && dot(crossProd, normal) < 0) {
+    angle = -angle;
+  }
+  return angle;
+}
+
+export function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function toMatrix4(columns) {
+  return [
+    columns[0].x, columns[1].x, columns[2].x, columns[3]?.x ?? 0,
+    columns[0].y, columns[1].y, columns[2].y, columns[3]?.y ?? 0,
+    columns[0].z, columns[1].z, columns[2].z, columns[3]?.z ?? 0,
+    0, 0, 0, 1,
+  ];
+}
+
+export function orthonormalize(basisX, basisY, basisZ) {
+  const x = normalize(basisX);
+  const z = normalize(cross(x, basisY));
+  const y = normalize(cross(z, x));
+  return { x, y, z };
+}
+
+export function buildLookAt(forward, up) {
+  const z = normalize(forward);
+  const x = normalize(cross(up, z));
+  const y = cross(z, x);
+  return { x, y, z };
+}
+
+export function ensureOrthogonalAxes(axes) {
+  const { x, y, z } = axes;
+  const ortho = orthonormalize(x, y, z);
+  return { x: ortho.x, y: ortho.y, z: ortho.z };
+}
+
+export function nearlyZero(value, epsilon = EPSILON) {
+  return Math.abs(value) <= epsilon;
+}
+
+export function clampMagnitude(value, epsilon = EPSILON) {
+  return nearlyZero(value, epsilon) ? 0 : value;
+}
+
+export function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+export function lerpVector(a, b, t) {
+  return {
+    x: lerp(a.x, b.x, t),
+    y: lerp(a.y, b.y, t),
+    z: lerp(a.z, b.z, t),
+  };
+}
+
+export function quaternionSlerp(a, b, t) {
+  let cosHalfTheta = a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z;
+  if (cosHalfTheta < 0) {
+    b = { x: -b.x, y: -b.y, z: -b.z, w: -b.w };
+    cosHalfTheta = -cosHalfTheta;
+  }
+  if (Math.abs(cosHalfTheta) >= 1.0) {
+    return { ...a };
+  }
+  const halfTheta = Math.acos(cosHalfTheta);
+  const sinHalfTheta = Math.sqrt(1.0 - cosHalfTheta * cosHalfTheta);
+  if (Math.abs(sinHalfTheta) < EPSILON) {
+    return {
+      w: 0.5 * (a.w + b.w),
+      x: 0.5 * (a.x + b.x),
+      y: 0.5 * (a.y + b.y),
+      z: 0.5 * (a.z + b.z),
+    };
+  }
+  const ratioA = Math.sin((1 - t) * halfTheta) / sinHalfTheta;
+  const ratioB = Math.sin(t * halfTheta) / sinHalfTheta;
+  return {
+    w: a.w * ratioA + b.w * ratioB,
+    x: a.x * ratioA + b.x * ratioB,
+    y: a.y * ratioA + b.y * ratioB,
+    z: a.z * ratioA + b.z * ratioB,
+  };
+}
+
+export function rayPlaneIntersection(ray, planeNormal, planePoint) {
+  const denom = dot(ray.direction, planeNormal);
+  if (nearlyZero(denom)) {
+    return null;
+  }
+  const diff = subtract(planePoint, ray.origin);
+  const t = dot(diff, planeNormal) / denom;
+  if (t < 0) {
+    return null;
+  }
+  return add(ray.origin, scale(ray.direction, t));
+}
+
+export const IDENTITY_QUATERNION = { x: 0, y: 0, z: 0, w: 1 };
+export const ZERO_VECTOR = { x: 0, y: 0, z: 0 };
+export const UNIT_X = { x: 1, y: 0, z: 0 };
+export const UNIT_Y = { x: 0, y: 1, z: 0 };
+export const UNIT_Z = { x: 0, y: 0, z: 1 };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const math = await import(resolve(__dirname, '../src/math.js'));
+const solver = await import(resolve(__dirname, '../src/TransformSolver.js'));
+
+const results = [];
+
+function test(name, fn) {
+  try {
+    fn();
+    results.push({ name, status: 'passed' });
+  } catch (error) {
+    results.push({ name, status: 'failed', error });
+  }
+}
+
+test('vector normalization', () => {
+  const v = math.normalize({ x: 3, y: 4, z: 0 });
+  assert.ok(Math.abs(v.x - 0.6) < 1e-12);
+  assert.ok(Math.abs(v.y - 0.8) < 1e-12);
+  assert.equal(v.z, 0);
+});
+
+test('matrix TRS decomposition', () => {
+  const translation = { x: 10, y: -4, z: 3 };
+  const rotation = math.fromAxisAngle({ x: 0, y: 0, z: 1 }, Math.PI / 4);
+  const scale = { x: 2, y: 3, z: 4 };
+  const matrix = math.composeTransform(translation, rotation, scale);
+  const decomposed = math.decomposeTransform(matrix);
+  assert.ok(math.equalsEpsilon(decomposed.translation, translation, 1e-9));
+  assert.ok(math.equalsQuaternion(decomposed.rotation, rotation, 1e-9));
+  assert.ok(math.equalsEpsilon(decomposed.scale, scale, 1e-9));
+});
+
+test('axis drag translation delta', () => {
+  const axis = math.normalize({ x: 1, y: 0, z: 0 });
+  const pivot = { x: 0, y: 0, z: 0 };
+  const startRay = { origin: { x: 0, y: 0, z: 10 }, direction: math.normalize({ x: 0, y: 0, z: -1 }) };
+  const currentRay = { origin: { x: 1, y: 0, z: 10 }, direction: math.normalize({ x: 0, y: 0, z: -1 }) };
+  const session = solver.beginAxisTranslation({ axis, pivot, startRay, cameraDirection: { x: 0, y: 0, z: -1 } });
+  const delta = solver.updateAxisTranslation(session, currentRay);
+  assert.ok(Math.abs(delta.distance - 1) < 1e-6);
+  assert.ok(math.equalsEpsilon(delta.vector, { x: 1, y: 0, z: 0 }, 1e-6));
+});
+
+let failed = 0;
+for (const result of results) {
+  if (result.status === 'failed') {
+    failed++;
+    console.error(`\u274c ${result.name}`);
+    console.error(result.error);
+  } else {
+    console.log(`\u2705 ${result.name}`);
+  }
+}
+
+if (failed) {
+  console.error(`\n${failed} test(s) failed.`);
+  process.exit(1);
+}
+
+console.log(`\nAll ${results.length} tests passed.`);


### PR DESCRIPTION
## Summary
- implement a modular Cesium universal manipulator with gizmo rendering, picking, snapping, and pivot/orientation management
- add math utilities, transform solvers, HUD overlay, and controller wiring for translate/rotate/scale workflows
- document usage, ship a demo scene, and provide simple build/test scripts

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0c85d1bec832dbce323bb8b837b66