### PR TITLE
feat: add universal manipulator library and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,138 @@
-# cesium-universal-manipulator
+# Cesium Universal Manipulator
+
+A reusable translate / rotate / scale gizmo for [CesiumJS 1.133](https://cesium.com/learn/cesiumjs/ref-doc/). The library keeps the manipulator responsive in globe scenes, supports multiple coordinate frames and pivots, and exposes a high-level API for integrating with Cesium `Scene`, `Entity`, or custom objects.
+
+## Features
+
+- ✳️ Unified manipulator covering translate, rotate, and scale.
+- 🎯 Robust picking in screen space without relying on `pickPosition`.
+- 🧭 Orientation frames: global, local, view, ENU, normal, and gimbal.
+- 📍 Pivots: origin, median, cursor, and individual multi-selection.
+- 📐 Configurable snapping with Ctrl (step) and Shift (fine) support.
+- 🧮 Numerically stable solvers operating in ENU frames with quaternion rotations.
+- 🧩 Modular architecture (`FrameBuilder`, `TransformSolver`, `GizmoPrimitive`, `ManipulatorController`, `Snapper`, `PivotResolver`, `HudOverlay`).
+- 🧪 Vitest coverage for solvers, frames, and pivots.
+- 📘 Example application with interactive control panel and HUD overlay.
+
+## Getting Started
+
+### Installation
+
+```bash
+npm install cesium-universal-manipulator cesium
+```
+
+Ensure Cesium static assets are served alongside your application (see the [Cesium build guide](https://cesium.com/learn/cesiumjs-learn/cesiumjs-quickstart/)).
+
+### Basic Usage
+
+```ts
+import { Viewer, Matrix4 } from 'cesium';
+import { UniversalManipulator } from 'cesium-universal-manipulator';
+
+const viewer = new Viewer('viewer');
+
+// Wrap your Cesium target (Entity, Model, or custom matrix holder)
+const target = {
+  matrix: Matrix4.IDENTITY.clone(),
+  setMatrix(next: Matrix4) {
+    this.matrix = next;
+  }
+};
+
+const manipulator = new UniversalManipulator({
+  scene: viewer.scene,
+  target,
+  orientation: 'global',
+  pivot: 'origin',
+  snap: { translate: 0.5, rotate: Cesium.Math.toRadians(5), scale: 0.1 }
+});
+
+viewer.container.appendChild(manipulator.getHudElement());
+```
+
+Switch modes, orientation, and pivots at runtime:
+
+```ts
+manipulator.enable({ translate: true });
+manipulator.setOrientation('local');
+manipulator.setPivot('median');
+manipulator.setSnap({ rotate: Cesium.Math.toRadians(1) });
+```
+
+Destroy the manipulator when it is no longer required:
+
+```ts
+manipulator.destroy();
+```
+
+### Multi-target support
+
+Provide an array of targets when working with multiple objects. The manipulator resolves pivots (median, cursor, or individual) and applies transforms to each object while respecting its own local pivot.
+
+```ts
+manipulator.setTarget([targetA, targetB, targetC]);
+manipulator.setPivot('individual');
+```
+
+## Example Application
+
+Run the bundled demo with Vite to explore features such as multi-selection, snapping, and frame switching.
+
+```bash
+npm install
+npm run dev
+```
+
+Open the logged local URL to see the viewer, control panel, and HUD overlay. Use the selection checkboxes to toggle which boxes participate in the transform.
+
+## API Surface
+
+### `UniversalManipulator`
+
+| Method | Description |
+| --- | --- |
+| `setTarget(target | target[])` | Attach one or more transformation targets. |
+| `setOrientation(orientation)` | Switch orientation frame (`global`, `local`, `view`, `enu`, `normal`, `gimbal`). |
+| `setPivot(pivot)` | Choose pivot (`origin`, `median`, `cursor`, `individual`). |
+| `enable({ translate?, rotate?, scale? })` | Activate one of the manipulation modes. |
+| `setSnap(stepConfig)` | Configure snapping steps for translate, rotate, and scale. |
+| `setSize(screenPixelRadius, minScale, maxScale)` | Control screen-space scaling for gizmo size. |
+| `setShow(show)` | Toggle visibility. |
+| `destroy()` | Clean up primitives, handlers, and DOM overlay. |
+
+### Supporting Modules
+
+- **`FrameBuilder`** — Resolves reference frames (global/local/view/ENU/normal/gimbal).
+- **`TransformSolver`** — Converts cursor motion into axis/plane translations, rotations, and scaling with quaternion math.
+- **`Snapper`** — Applies translate/rotate/scale snapping with modifier-aware fine control.
+- **`PivotResolver`** — Handles multi-selection pivots and cursor-based pivots.
+- **`GizmoPrimitive`** — Renders axis primitives with screen-space scaling and highlighting hooks.
+- **`GizmoPicker`** — Implements screen-space picking against gizmo handles.
+- **`ManipulatorController`** — Pointer event state machine (hover, drag, cancel).
+- **`HudOverlay`** — DOM overlay for ΔX/ΔY/ΔZ, angles, and scale factors.
+
+## Project Structure
+
+```
+src/
+  core/              // math, frames, snapping, pivots, manipulator orchestration
+  interaction/       // picker and controller
+  render/            // Cesium primitives for gizmo visuals
+  utils/             // helpers for Cesium math conversions
+examples/            // Vite demo app with control panel
+tests/               // Vitest unit tests (solvers, frames, pivots)
+```
+
+## Testing
+
+```bash
+npm install
+npm run test
+```
+
+Vitest runs in Node and exercises math-heavy components (`TransformSolver`, `FrameBuilder`, `PivotResolver`).
+
+## License
+
+MIT

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cesium Universal Manipulator Demo</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cesium/1.133.0/Widgets/widgets.min.css" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <div id="app">
+      <div id="viewer"></div>
+      <div id="panel">
+        <h2>Manipulator Controls</h2>
+        <div class="control-group">
+          <label>Mode</label>
+          <select id="mode">
+            <option value="translate">Translate</option>
+            <option value="rotate">Rotate</option>
+            <option value="scale">Scale</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label>Orientation</label>
+          <select id="orientation">
+            <option value="global">Global</option>
+            <option value="local">Local</option>
+            <option value="view">View</option>
+            <option value="enu">ENU</option>
+            <option value="normal">Normal</option>
+            <option value="gimbal">Gimbal</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label>Pivot</label>
+          <select id="pivot">
+            <option value="origin">Origin</option>
+            <option value="median">Median</option>
+            <option value="cursor">Cursor</option>
+            <option value="individual">Individual</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label>Selection</label>
+          <div class="selection">
+            <label><input type="checkbox" class="entity-selector" data-index="0" checked /> Box A</label>
+            <label><input type="checkbox" class="entity-selector" data-index="1" checked /> Box B</label>
+            <label><input type="checkbox" class="entity-selector" data-index="2" /> Box C</label>
+          </div>
+        </div>
+        <div class="control-group">
+          <label>Snap (m)</label>
+          <input id="snap-translate" type="number" step="0.1" value="0.5" />
+        </div>
+        <div class="control-group">
+          <label>Snap Angle (deg)</label>
+          <input id="snap-rotate" type="number" step="1" value="5" />
+        </div>
+        <div class="control-group">
+          <label>Snap Scale</label>
+          <input id="snap-scale" type="number" step="0.1" value="0.1" />
+        </div>
+      </div>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1,0 +1,132 @@
+import { Viewer, Matrix4, Cartesian3, Color, Quaternion, Entity, Math as CesiumMath } from 'cesium';
+import { UniversalManipulator, type ManipulatorTarget } from '../src';
+
+class EntityTarget implements ManipulatorTarget {
+  public readonly entity: Entity;
+  private readonly viewer: Viewer;
+  private readonly baseDimensions?: Cartesian3;
+
+  constructor(entity: Entity, viewer: Viewer) {
+    this.entity = entity;
+    this.viewer = viewer;
+    if (entity.box) {
+      this.baseDimensions = Cartesian3.clone(entity.box.dimensions?.getValue(viewer.clock.currentTime) ?? new Cartesian3(1, 1, 1));
+    }
+  }
+
+  public getMatrix(): Matrix4 {
+    return this.entity.computeModelMatrix(this.viewer.clock.currentTime, new Matrix4());
+  }
+
+  public setMatrix(matrix: Matrix4): void {
+    const translation = Matrix4.getTranslation(matrix, new Cartesian3());
+    const rotation = new Quaternion();
+    const scale = new Cartesian3();
+    Matrix4.decompose(matrix, translation, rotation, scale);
+    this.entity.position = translation;
+    this.entity.orientation = rotation;
+    if (this.entity.box && this.baseDimensions) {
+      const scaled = new Cartesian3(
+        this.baseDimensions.x * scale.x,
+        this.baseDimensions.y * scale.y,
+        this.baseDimensions.z * scale.z
+      );
+      this.entity.box.dimensions = scaled;
+    }
+  }
+}
+
+const viewer = new Viewer('viewer', {
+  terrain: undefined,
+  infoBox: false,
+  selectionIndicator: false,
+  baseLayerPicker: true
+});
+
+viewer.scene.globe.depthTestAgainstTerrain = true;
+
+function createBox(position: Cartesian3, dimensions: Cartesian3, color: Color): Entity {
+  return viewer.entities.add({
+    position,
+    box: {
+      dimensions,
+      material: color
+    }
+  });
+}
+
+const boxes = [
+  createBox(Cartesian3.fromDegrees(-75.59777, 40.03883, 300), new Cartesian3(200, 200, 200), Color.RED.withAlpha(0.7)),
+  createBox(Cartesian3.fromDegrees(-75.6, 40.03883, 300), new Cartesian3(150, 150, 150), Color.GREEN.withAlpha(0.7)),
+  createBox(Cartesian3.fromDegrees(-75.59, 40.03883, 300), new Cartesian3(100, 250, 180), Color.BLUE.withAlpha(0.7))
+];
+
+const targets = boxes.map((box) => new EntityTarget(box, viewer));
+
+const manipulator = new UniversalManipulator({
+  scene: viewer.scene,
+  target: targets[0],
+  orientation: 'global',
+  pivot: 'origin',
+  snap: { translate: 0.5, rotate: CesiumMath.toRadians(5), scale: 0.1 }
+});
+
+viewer.container.appendChild(manipulator.getHudElement());
+
+let selection: EntityTarget[] = [targets[0]];
+
+function updateSelection(): void {
+  const checkboxes = Array.from(document.querySelectorAll('.entity-selector')) as HTMLInputElement[];
+  const selectedTargets = checkboxes
+    .filter((input) => input.checked)
+    .map((input) => targets[parseInt(input.dataset.index ?? '0', 10)]);
+  selection = selectedTargets.length > 0 ? selectedTargets : [targets[0]];
+  manipulator.setTarget(selection.length === 1 ? selection[0] : selection);
+}
+
+function bindControls(): void {
+  const mode = document.getElementById('mode') as HTMLSelectElement;
+  const orientation = document.getElementById('orientation') as HTMLSelectElement;
+  const pivot = document.getElementById('pivot') as HTMLSelectElement;
+  const snapTranslate = document.getElementById('snap-translate') as HTMLInputElement;
+  const snapRotate = document.getElementById('snap-rotate') as HTMLInputElement;
+  const snapScale = document.getElementById('snap-scale') as HTMLInputElement;
+
+  mode.addEventListener('change', () => {
+    const value = mode.value as 'translate' | 'rotate' | 'scale';
+    manipulator.enable({ translate: value === 'translate', rotate: value === 'rotate', scale: value === 'scale' });
+  });
+
+  orientation.addEventListener('change', () => {
+    manipulator.setOrientation(orientation.value as any);
+  });
+
+  pivot.addEventListener('change', () => {
+    manipulator.setPivot(pivot.value as any);
+  });
+
+  const updateSnap = () => {
+    manipulator.setSnap({
+      translate: parseFloat(snapTranslate.value),
+      rotate: CesiumMath.toRadians(parseFloat(snapRotate.value)),
+      scale: parseFloat(snapScale.value)
+    });
+  };
+
+  snapTranslate.addEventListener('input', updateSnap);
+  snapRotate.addEventListener('input', updateSnap);
+  snapScale.addEventListener('input', updateSnap);
+}
+
+function bindSelectionControls(): void {
+  const checkboxes = Array.from(document.querySelectorAll('.entity-selector')) as HTMLInputElement[];
+  checkboxes.forEach((checkbox) => {
+    checkbox.addEventListener('change', updateSelection);
+  });
+  updateSelection();
+}
+
+bindControls();
+bindSelectionControls();
+
+viewer.zoomTo(viewer.entities);

--- a/examples/style.css
+++ b/examples/style.css
@@ -1,0 +1,79 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: 'Segoe UI', sans-serif;
+  color: #f3f3f3;
+  background: #1c1f2b;
+}
+
+#app {
+  display: flex;
+  height: 100%;
+}
+
+#viewer {
+  flex: 1;
+  position: relative;
+}
+
+#panel {
+  width: 320px;
+  padding: 16px;
+  background: rgba(20, 22, 32, 0.95);
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  overflow-y: auto;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 12px;
+}
+
+.control-group label {
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+
+.control-group select,
+.control-group input {
+  padding: 8px;
+  border-radius: 4px;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.selection {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.selection label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.cum-hud {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  padding: 8px 12px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.4;
+  pointer-events: none;
+  z-index: 100;
+}
+
+.cum-hud__translation,
+.cum-hud__rotation,
+.cum-hud__scale {
+  white-space: nowrap;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "cesium-universal-manipulator",
+  "version": "0.1.0",
+  "description": "Universal translate/rotate/scale manipulator for CesiumJS",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && vite build",
+    "dev": "vite",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "cesium",
+    "manipulator",
+    "gizmo",
+    "translate",
+    "rotate",
+    "scale"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cesium": "1.133.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "typescript": "5.4.5",
+    "vite": "5.2.8",
+    "vitest": "1.5.0"
+  }
+}

--- a/src/core/FrameBuilder.ts
+++ b/src/core/FrameBuilder.ts
@@ -1,0 +1,113 @@
+import {
+  Cartesian3,
+  Matrix3,
+  Matrix4,
+  Quaternion,
+  Transforms,
+  Camera
+} from 'cesium';
+import type { FrameState, Orientation } from './types';
+import { matrixToQuaternion, quaternionToMatrix } from '../utils/cesium';
+
+export interface FrameBuilderOptions {
+  camera?: Camera;
+  viewUp?: Cartesian3;
+  normalProvider?: () => Cartesian3;
+}
+
+const scratchMatrix3 = new Matrix3();
+const scratchQuaternion = new Quaternion();
+
+export class FrameBuilder {
+  private readonly options: FrameBuilderOptions;
+
+  constructor(options: FrameBuilderOptions = {}) {
+    this.options = options;
+  }
+
+  public setCamera(camera: Camera): void {
+    this.options.camera = camera;
+  }
+
+  public build(origin: Cartesian3, worldMatrix: Matrix4, orientation: Orientation): FrameState {
+    switch (orientation) {
+      case 'global':
+        return this.buildGlobal(origin);
+      case 'local':
+        return this.buildLocal(origin, worldMatrix);
+      case 'view':
+        return this.buildView(origin);
+      case 'enu':
+        return this.buildEnu(origin);
+      case 'normal':
+        return this.buildNormal(origin, worldMatrix);
+      case 'gimbal':
+      default:
+        return this.buildGimbal(origin, worldMatrix);
+    }
+  }
+
+  private buildGlobal(origin: Cartesian3): FrameState {
+    const translation = Cartesian3.clone(origin, new Cartesian3());
+    const matrix = Matrix4.fromRotationTranslation(Matrix3.IDENTITY, translation, new Matrix4());
+    const axes = Matrix3.IDENTITY.clone();
+    return { origin: translation, axes, matrix };
+  }
+
+  private buildLocal(origin: Cartesian3, matrix: Matrix4): FrameState {
+    const rotation = Matrix3.fromMatrix4(matrix, new Matrix3());
+    const translation = Cartesian3.clone(origin, new Cartesian3());
+    const axes = Matrix3.clone(rotation, new Matrix3());
+    const frameMatrix = Matrix4.fromRotationTranslation(rotation, translation, new Matrix4());
+    return { origin: translation, axes, matrix: frameMatrix };
+  }
+
+  private buildView(origin: Cartesian3): FrameState {
+    const camera = this.options.camera;
+    if (!camera) {
+      return this.buildGlobal(origin);
+    }
+    const right = Cartesian3.normalize(camera.right, new Cartesian3());
+    const up = Cartesian3.normalize(camera.up, new Cartesian3());
+    const forward = Cartesian3.normalize(camera.direction, new Cartesian3());
+    const axes = Matrix3.clone(Matrix3.IDENTITY, new Matrix3());
+    Matrix3.setColumn(axes, 0, right, axes);
+    Matrix3.setColumn(axes, 1, up, axes);
+    Matrix3.setColumn(axes, 2, forward, axes);
+    const translation = Cartesian3.clone(origin, new Cartesian3());
+    const frameMatrix = Matrix4.fromRotationTranslation(axes, translation, new Matrix4());
+    return { origin: translation, axes, matrix: frameMatrix };
+  }
+
+  private buildEnu(origin: Cartesian3): FrameState {
+    const translation = Cartesian3.clone(origin, new Cartesian3());
+    const frameMatrix = Transforms.eastNorthUpToFixedFrame(translation, undefined, new Matrix4());
+    const axes = Matrix3.fromMatrix4(frameMatrix, new Matrix3());
+    return { origin: translation, axes, matrix: frameMatrix };
+  }
+
+  private buildNormal(origin: Cartesian3, matrix: Matrix4): FrameState {
+    const normalProvider = this.options.normalProvider;
+    const normal = normalProvider ? normalProvider() : Matrix4.getColumn(matrix, 2, new Cartesian3());
+    const up = Cartesian3.normalize(normal, new Cartesian3());
+    const xAxis = Matrix4.getColumn(matrix, 0, new Cartesian3());
+    Cartesian3.normalize(xAxis, xAxis);
+    const yAxis = Cartesian3.cross(up, xAxis, new Cartesian3());
+    Cartesian3.normalize(yAxis, yAxis);
+    const correctedXAxis = Cartesian3.cross(yAxis, up, new Cartesian3());
+    const rotation = Matrix3.fromColumns(correctedXAxis, yAxis, up, new Matrix3());
+    const translation = Cartesian3.clone(origin, new Cartesian3());
+    const frameMatrix = Matrix4.fromRotationTranslation(rotation, translation, new Matrix4());
+    return { origin: translation, axes: rotation, matrix: frameMatrix };
+  }
+
+  private buildGimbal(origin: Cartesian3, matrix: Matrix4): FrameState {
+    const rotation = Matrix3.fromMatrix4(matrix, new Matrix3());
+    const quaternion = matrixToQuaternion(rotation);
+    Quaternion.normalize(quaternion, scratchQuaternion);
+    const stabilised = quaternionToMatrix(scratchQuaternion);
+    const translation = Cartesian3.clone(origin, new Cartesian3());
+    const frameMatrix = Matrix4.fromRotationTranslation(stabilised, translation, new Matrix4());
+    return { origin: translation, axes: stabilised, matrix: frameMatrix };
+  }
+}

--- a/src/core/HudOverlay.ts
+++ b/src/core/HudOverlay.ts
@@ -1,0 +1,42 @@
+import { Cartesian3, Math as CesiumMath } from 'cesium';
+import type { DeltaTransform } from './types';
+
+export interface HudOverlayOptions {
+  container?: HTMLElement;
+}
+
+export class HudOverlay {
+  private readonly element: HTMLElement;
+  private readonly translationEl: HTMLElement;
+  private readonly rotationEl: HTMLElement;
+  private readonly scaleEl: HTMLElement;
+
+  constructor(options: HudOverlayOptions = {}) {
+    this.element = options.container ?? document.createElement('div');
+    this.element.className = 'cum-hud';
+    this.translationEl = document.createElement('div');
+    this.rotationEl = document.createElement('div');
+    this.scaleEl = document.createElement('div');
+    this.translationEl.className = 'cum-hud__translation';
+    this.rotationEl.className = 'cum-hud__rotation';
+    this.scaleEl.className = 'cum-hud__scale';
+    this.element.append(this.translationEl, this.rotationEl, this.scaleEl);
+  }
+
+  public getElement(): HTMLElement {
+    return this.element;
+  }
+
+  public update(delta: DeltaTransform): void {
+    this.translationEl.textContent = `ΔX ${delta.translation.x.toFixed(3)} m | ΔY ${delta.translation.y.toFixed(3)} m | ΔZ ${delta.translation.z.toFixed(3)} m`;
+    const angle = CesiumMath.toDegrees(2 * Math.acos(delta.rotation.w));
+    this.rotationEl.textContent = `Δθ ${angle.toFixed(2)}°`;
+    this.scaleEl.textContent = `Scale ${delta.scale.x.toFixed(3)} ${delta.scale.y.toFixed(3)} ${delta.scale.z.toFixed(3)}`;
+  }
+
+  public reset(): void {
+    this.translationEl.textContent = 'ΔX 0 m | ΔY 0 m | ΔZ 0 m';
+    this.rotationEl.textContent = 'Δθ 0°';
+    this.scaleEl.textContent = 'Scale 1 1 1';
+  }
+}

--- a/src/core/PivotResolver.ts
+++ b/src/core/PivotResolver.ts
@@ -1,0 +1,67 @@
+import { Cartesian3, Matrix4 } from 'cesium';
+import type { ManipulatorTarget, Pivot } from './types';
+import { cartesianArrayMedian } from '../utils/cesium';
+
+export interface PivotResult {
+  pivotPoint: Cartesian3;
+  perTarget?: Map<ManipulatorTarget, Cartesian3>;
+}
+
+export class PivotResolver {
+  private cursorPosition: Cartesian3 | undefined;
+
+  public setCursor(position: Cartesian3 | undefined): void {
+    this.cursorPosition = position ? Cartesian3.clone(position, new Cartesian3()) : undefined;
+  }
+
+  public resolve(targets: ManipulatorTarget[], pivot: Pivot): PivotResult {
+    switch (pivot) {
+      case 'median':
+        return this.resolveMedian(targets);
+      case 'cursor':
+        return this.resolveCursor(targets);
+      case 'individual':
+        return this.resolveIndividual(targets);
+      case 'origin':
+      default:
+        return this.resolveOrigin(targets);
+    }
+  }
+
+  private resolveOrigin(targets: ManipulatorTarget[]): PivotResult {
+    const first = targets[0];
+    const matrix = this.getMatrix(first);
+    const translation = Matrix4.getTranslation(matrix, new Cartesian3());
+    return { pivotPoint: translation };
+  }
+
+  private resolveMedian(targets: ManipulatorTarget[]): PivotResult {
+    const positions = targets.map((target) => Matrix4.getTranslation(this.getMatrix(target), new Cartesian3()));
+    const median = cartesianArrayMedian(positions);
+    return { pivotPoint: median };
+  }
+
+  private resolveCursor(targets: ManipulatorTarget[]): PivotResult {
+    if (!this.cursorPosition) {
+      return this.resolveMedian(targets);
+    }
+    return { pivotPoint: Cartesian3.clone(this.cursorPosition, new Cartesian3()) };
+  }
+
+  private resolveIndividual(targets: ManipulatorTarget[]): PivotResult {
+    const perTarget = new Map<ManipulatorTarget, Cartesian3>();
+    targets.forEach((target) => {
+      const translation = Matrix4.getTranslation(this.getMatrix(target), new Cartesian3());
+      perTarget.set(target, translation);
+    });
+    const first = perTarget.get(targets[0]);
+    return { pivotPoint: first ?? new Cartesian3(), perTarget };
+  }
+
+  private getMatrix(target: ManipulatorTarget): Matrix4 {
+    if ('getMatrix' in target) {
+      return target.getMatrix();
+    }
+    return target.matrix;
+  }
+}

--- a/src/core/Snapper.ts
+++ b/src/core/Snapper.ts
@@ -1,0 +1,56 @@
+import { Math as CesiumMath } from 'cesium';
+import type { SnapContext, SnapOptions } from './types';
+
+export class Snapper {
+  private translateStep: number | undefined;
+  private rotateStep: number | undefined;
+  private scaleStep: number | undefined;
+
+  constructor(options: SnapOptions = {}) {
+    this.update(options);
+  }
+
+  public update(options: SnapOptions): void {
+    this.translateStep = options.translate;
+    this.rotateStep = options.rotate;
+    this.scaleStep = options.scale;
+  }
+
+  public snapTranslation(value: number, context: SnapContext): number {
+    if (!this.translateStep) {
+      return this.applyFineAdjustment(value, context);
+    }
+    return this.snapValue(value, this.translateStep, context);
+  }
+
+  public snapRotation(value: number, context: SnapContext): number {
+    const step = this.rotateStep ?? CesiumMath.toRadians(5);
+    return this.snapValue(value, step, context);
+  }
+
+  public snapScale(value: number, context: SnapContext): number {
+    if (!this.scaleStep) {
+      return this.applyFineAdjustment(value, context);
+    }
+    return this.snapValue(value, this.scaleStep, context);
+  }
+
+  private snapValue(value: number, step: number, context: SnapContext): number {
+    if (context.shiftKey) {
+      return value;
+    }
+    const effectiveStep = context.ctrlKey ? step : step * 0.2;
+    if (effectiveStep <= 0) {
+      return value;
+    }
+    const snapped = Math.round(value / effectiveStep) * effectiveStep;
+    return context.ctrlKey ? snapped : this.applyFineAdjustment(snapped, context);
+  }
+
+  private applyFineAdjustment(value: number, context: SnapContext): number {
+    if (!context.shiftKey) {
+      return value;
+    }
+    return value * 0.1;
+  }
+}

--- a/src/core/TransformSolver.ts
+++ b/src/core/TransformSolver.ts
@@ -1,0 +1,192 @@
+import {
+  Cartesian3,
+  Matrix3,
+  Matrix4,
+  Quaternion,
+  Math as CesiumMath
+} from 'cesium';
+import type { Axis, DeltaTransform, FrameState, SnapContext } from './types';
+import { Snapper } from './Snapper';
+import { axisAngleToQuaternion } from '../utils/math';
+
+const scratchMatrix = new Matrix4();
+
+function axisIndex(axis: Axis): number {
+  switch (axis) {
+    case 'x':
+      return 0;
+    case 'y':
+      return 1;
+    case 'z':
+      return 2;
+  }
+}
+
+export class TransformSolver {
+  constructor(private readonly snapper: Snapper) {}
+
+  public solveAxisTranslation(
+    start: Cartesian3,
+    current: Cartesian3,
+    axis: Axis,
+    frame: FrameState,
+    context: SnapContext
+  ): DeltaTransform {
+    const axisVector = Matrix3.getColumn(frame.axes, axisIndex(axis), new Cartesian3());
+    Cartesian3.normalize(axisVector, axisVector);
+    const deltaWorld = Cartesian3.subtract(current, start, new Cartesian3());
+    const amount = Cartesian3.dot(deltaWorld, axisVector);
+    const snapped = this.snapper.snapTranslation(amount, context);
+    const translation = Cartesian3.multiplyByScalar(axisVector, snapped, new Cartesian3());
+    return {
+      translation,
+      rotation: Quaternion.IDENTITY.clone(),
+      scale: new Cartesian3(1, 1, 1)
+    };
+  }
+
+  public solvePlaneTranslation(
+    start: Cartesian3,
+    current: Cartesian3,
+    axisA: Axis,
+    axisB: Axis,
+    frame: FrameState,
+    context: SnapContext
+  ): DeltaTransform {
+    const columnA = Matrix3.getColumn(frame.axes, axisIndex(axisA), new Cartesian3());
+    const columnB = Matrix3.getColumn(frame.axes, axisIndex(axisB), new Cartesian3());
+    const deltaWorld = Cartesian3.subtract(current, start, new Cartesian3());
+    const amountA = Cartesian3.dot(deltaWorld, Cartesian3.normalize(columnA, columnA));
+    const amountB = Cartesian3.dot(deltaWorld, Cartesian3.normalize(columnB, columnB));
+    const snappedA = this.snapper.snapTranslation(amountA, context);
+    const snappedB = this.snapper.snapTranslation(amountB, context);
+    const translation = Cartesian3.add(
+      Cartesian3.multiplyByScalar(columnA, snappedA, new Cartesian3()),
+      Cartesian3.multiplyByScalar(columnB, snappedB, new Cartesian3()),
+      new Cartesian3()
+    );
+    return {
+      translation,
+      rotation: Quaternion.IDENTITY.clone(),
+      scale: new Cartesian3(1, 1, 1)
+    };
+  }
+
+  public solveAxisRotation(
+    start: Cartesian3,
+    current: Cartesian3,
+    axis: Axis,
+    frame: FrameState,
+    context: SnapContext
+  ): DeltaTransform {
+    const origin = frame.origin;
+    const axisVector = Matrix3.getColumn(frame.axes, axisIndex(axis), new Cartesian3());
+    const startVector = Cartesian3.subtract(start, origin, new Cartesian3());
+    const currentVector = Cartesian3.subtract(current, origin, new Cartesian3());
+    Cartesian3.normalize(startVector, startVector);
+    Cartesian3.normalize(currentVector, currentVector);
+    const dot = CesiumMath.clamp(Cartesian3.dot(startVector, currentVector), -1, 1);
+    let angle = Math.acos(dot);
+    const cross = Cartesian3.cross(startVector, currentVector, new Cartesian3());
+    if (Cartesian3.dot(cross, axisVector) < 0) {
+      angle *= -1;
+    }
+    const snapped = this.snapper.snapRotation(angle, context);
+    const rotation = axisAngleToQuaternion(axisVector, snapped, new Quaternion());
+    return {
+      translation: new Cartesian3(0, 0, 0),
+      rotation,
+      scale: new Cartesian3(1, 1, 1)
+    };
+  }
+
+  public solveViewRotation(
+    start: Cartesian3,
+    current: Cartesian3,
+    viewNormal: Cartesian3,
+    frame: FrameState,
+    context: SnapContext
+  ): DeltaTransform {
+    const origin = frame.origin;
+    const normal = Cartesian3.normalize(viewNormal, new Cartesian3());
+    const startVector = Cartesian3.subtract(start, origin, new Cartesian3());
+    const currentVector = Cartesian3.subtract(current, origin, new Cartesian3());
+    Cartesian3.normalize(startVector, startVector);
+    Cartesian3.normalize(currentVector, currentVector);
+    const dot = CesiumMath.clamp(Cartesian3.dot(startVector, currentVector), -1, 1);
+    let angle = Math.acos(dot);
+    const cross = Cartesian3.cross(startVector, currentVector, new Cartesian3());
+    if (Cartesian3.dot(cross, normal) < 0) {
+      angle *= -1;
+    }
+    const snapped = this.snapper.snapRotation(angle, context);
+    const rotation = axisAngleToQuaternion(normal, snapped, new Quaternion());
+    return {
+      translation: new Cartesian3(0, 0, 0),
+      rotation,
+      scale: new Cartesian3(1, 1, 1)
+    };
+  }
+
+  public solveAxisScale(
+    start: Cartesian3,
+    current: Cartesian3,
+    axis: Axis,
+    frame: FrameState,
+    context: SnapContext
+  ): DeltaTransform {
+    const axisVector = Matrix3.getColumn(frame.axes, axisIndex(axis), new Cartesian3());
+    const startProjection = Cartesian3.dot(
+      Cartesian3.subtract(start, frame.origin, new Cartesian3()),
+      Cartesian3.normalize(axisVector, axisVector)
+    );
+    const currentProjection = Cartesian3.dot(
+      Cartesian3.subtract(current, frame.origin, new Cartesian3()),
+      axisVector
+    );
+    const delta = currentProjection - startProjection;
+    const snapped = this.snapper.snapScale(delta, context);
+    const scale = new Cartesian3(1, 1, 1);
+    if (axis === 'x') {
+      scale.x = 1 + snapped;
+    } else if (axis === 'y') {
+      scale.y = 1 + snapped;
+    } else {
+      scale.z = 1 + snapped;
+    }
+    return {
+      translation: new Cartesian3(0, 0, 0),
+      rotation: Quaternion.IDENTITY.clone(),
+      scale
+    };
+  }
+
+  public solveUniformScale(
+    start: Cartesian3,
+    current: Cartesian3,
+    frame: FrameState,
+    context: SnapContext
+  ): DeltaTransform {
+    const startDistance = Cartesian3.distance(start, frame.origin);
+    const currentDistance = Cartesian3.distance(current, frame.origin);
+    const factor = currentDistance / (startDistance === 0 ? 1 : startDistance);
+    const snappedFactor = 1 + this.snapper.snapScale(factor - 1, context);
+    const scale = new Cartesian3(snappedFactor, snappedFactor, snappedFactor);
+    return {
+      translation: new Cartesian3(0, 0, 0),
+      rotation: Quaternion.IDENTITY.clone(),
+      scale
+    };
+  }
+
+  public applyDelta(matrix: Matrix4, delta: DeltaTransform): Matrix4 {
+    const trsMatrix = Matrix4.fromTranslationQuaternionRotationScale(
+      delta.translation,
+      delta.rotation,
+      delta.scale,
+      new Matrix4()
+    );
+    Matrix4.multiply(matrix, trsMatrix, scratchMatrix);
+    return Matrix4.clone(scratchMatrix, new Matrix4());
+  }
+}

--- a/src/core/UniversalManipulator.ts
+++ b/src/core/UniversalManipulator.ts
@@ -1,0 +1,328 @@
+import {
+  Cartesian2,
+  Cartesian3,
+  Matrix3,
+  Matrix4,
+  Plane,
+  Ray,
+  IntersectionTests,
+  Scene,
+  Camera,
+  Math as CesiumMath,
+  SceneTransforms
+} from 'cesium';
+import type {
+  Axis,
+  DeltaTransform,
+  FrameState,
+  ManipulatorOptions,
+  ManipulatorTarget,
+  Mode,
+  Orientation,
+  Pivot,
+  SnapOptions
+} from './types';
+import { FrameBuilder } from './FrameBuilder';
+import { GizmoPrimitive } from '../render/GizmoPrimitive';
+import { GizmoPicker, GizmoHit } from '../interaction/GizmoPicker';
+import { ManipulatorController } from '../interaction/ManipulatorController';
+import { Snapper } from './Snapper';
+import { TransformSolver } from './TransformSolver';
+import { PivotResolver } from './PivotResolver';
+import { HudOverlay } from './HudOverlay';
+
+export interface UniversalManipulatorOptions extends ManipulatorOptions {
+  scene: Scene;
+  camera?: Camera;
+  hudContainer?: HTMLElement;
+}
+
+interface ActiveDragState {
+  hit: GizmoHit;
+  startWindow: Cartesian2;
+  startWorld: Cartesian3;
+  pivot: Cartesian3;
+  baseMatrices: Map<ManipulatorTarget, Matrix4>;
+  perTargetPivot?: Map<ManipulatorTarget, Cartesian3>;
+}
+
+const scratchRay = new Ray();
+const scratchPlane = new Plane(Cartesian3.UNIT_Z, 0);
+const scratchMatrix = new Matrix4();
+
+export class UniversalManipulator {
+  public show = true;
+  private readonly scene: Scene;
+  private readonly camera: Camera;
+  private readonly snapper: Snapper;
+  private readonly solver: TransformSolver;
+  private readonly frameBuilder: FrameBuilder;
+  private readonly gizmo: GizmoPrimitive;
+  private readonly picker: GizmoPicker;
+  private readonly controller: ManipulatorController;
+  private readonly pivotResolver: PivotResolver;
+  private readonly hud: HudOverlay;
+  private orientation: Orientation = 'global';
+  private pivot: Pivot = 'origin';
+  private mode: Mode = 'translate';
+  private size = { screenPixelRadius: 90, minScale: 0.6, maxScale: 4 };
+  private targets: ManipulatorTarget[] = [];
+  private frame: FrameState | undefined;
+  private drag: ActiveDragState | undefined;
+
+  constructor(options: UniversalManipulatorOptions) {
+    this.scene = options.scene;
+    this.camera = options.camera ?? options.scene.camera;
+    this.snapper = new Snapper(options.snap ?? {});
+    this.solver = new TransformSolver(this.snapper);
+    this.frameBuilder = new FrameBuilder({ camera: this.camera });
+    this.pivotResolver = new PivotResolver();
+    this.gizmo = new GizmoPrimitive({ scene: this.scene });
+    this.picker = new GizmoPicker(this.scene);
+    this.hud = new HudOverlay({ container: options.hudContainer });
+    this.controller = new ManipulatorController(this.scene, this.picker, {
+      onHover: (hit) => this.onHover(hit),
+      onDragStart: (hit, position) => this.onDragStart(hit, position),
+      onDragMove: (position) => this.onDragMove(position),
+      onDragEnd: (cancelled) => this.onDragEnd(cancelled)
+    });
+    if (options.target) {
+      this.setTarget(options.target);
+    }
+    if (options.orientation) {
+      this.orientation = options.orientation;
+    }
+    if (options.pivot) {
+      this.pivot = options.pivot;
+    }
+    if (options.snap) {
+      this.snapper.update(options.snap);
+    }
+    if (options.size) {
+      this.setSize(options.size.screenPixelRadius ?? 90, options.size.minScale ?? 0.6, options.size.maxScale ?? 4);
+    }
+    this.updateFrame();
+  }
+
+  public destroy(): void {
+    this.controller.destroy();
+    this.gizmo.destroy();
+  }
+
+  public enable(options: { translate?: boolean; rotate?: boolean; scale?: boolean }): void {
+    if (options.translate) {
+      this.mode = 'translate';
+    } else if (options.rotate) {
+      this.mode = 'rotate';
+    } else if (options.scale) {
+      this.mode = 'scale';
+    }
+    this.controller.setMode(this.mode);
+  }
+
+  public setTarget(target: ManipulatorTarget | ManipulatorTarget[]): void {
+    this.targets = Array.isArray(target) ? target : [target];
+    this.updateFrame();
+  }
+
+  public setOrientation(orientation: Orientation): void {
+    this.orientation = orientation;
+    this.updateFrame();
+  }
+
+  public setPivot(pivot: Pivot): void {
+    this.pivot = pivot;
+    this.updateFrame();
+  }
+
+  public setSnap(stepConfig: SnapOptions): void {
+    this.snapper.update(stepConfig);
+  }
+
+  public setSize(screenPixelRadius: number, minScale: number, maxScale: number): void {
+    this.size = { screenPixelRadius, minScale, maxScale };
+  }
+
+  public setShow(show: boolean): void {
+    this.show = show;
+    this.gizmo.setShow(show);
+  }
+
+  public getHudElement(): HTMLElement {
+    return this.hud.getElement();
+  }
+
+  private updateFrame(): void {
+    if (this.targets.length === 0) {
+      this.frame = undefined;
+      this.gizmo.setShow(false);
+      this.controller.setFrame(undefined);
+      return;
+    }
+    const pivotResult = this.pivotResolver.resolve(this.targets, this.pivot);
+    const primaryMatrix = this.getTargetMatrix(this.targets[0]);
+    this.frame = this.frameBuilder.build(pivotResult.pivotPoint, primaryMatrix, this.orientation);
+    this.gizmo.setShow(this.show);
+    const scale = this.computeScreenScale(pivotResult.pivotPoint);
+    this.gizmo.update(this.frame, scale);
+    this.controller.setFrame(this.frame);
+  }
+
+  private computeScreenScale(position: Cartesian3): number {
+    const canvas = this.scene.canvas;
+    const windowPosition = SceneTransforms.worldToWindowCoordinates(this.scene, position);
+    if (!windowPosition) {
+      return 1;
+    }
+    const distance = Cartesian3.distance(position, this.camera.position);
+    const fov = this.camera.frustum.fov ?? CesiumMath.PI_OVER_THREE;
+    const height = canvas.clientHeight;
+    const scale = (distance * Math.tan(fov / 2) * 2) / height;
+    return CesiumMath.clamp(scale * this.size.screenPixelRadius * 0.01, this.size.minScale, this.size.maxScale);
+  }
+
+  private onHover(hit: GizmoHit | undefined): void {
+    // In this simplified version we do not change visual state beyond HUD reset.
+    if (!hit) {
+      this.hud.reset();
+    }
+  }
+
+  private onDragStart(hit: GizmoHit, position: Cartesian2): void {
+    if (!this.frame) {
+      return;
+    }
+    const pivotResult = this.pivotResolver.resolve(this.targets, this.pivot);
+    const startWorld = this.intersectPointer(position, hit, pivotResult.pivotPoint);
+    if (!startWorld) {
+      return;
+    }
+    const baseMatrices = new Map<ManipulatorTarget, Matrix4>();
+    this.targets.forEach((target) => {
+      baseMatrices.set(target, Matrix4.clone(this.getTargetMatrix(target), new Matrix4()));
+    });
+    this.drag = {
+      hit,
+      startWindow: position,
+      startWorld,
+      pivot: pivotResult.pivotPoint,
+      baseMatrices,
+      perTargetPivot: pivotResult.perTarget
+    };
+  }
+
+  private onDragMove(position: Cartesian2): void {
+    if (!this.drag || !this.frame) {
+      return;
+    }
+    const currentWorld = this.intersectPointer(position, this.drag.hit, this.drag.pivot);
+    if (!currentWorld) {
+      return;
+    }
+    const context = { ctrlKey: false, shiftKey: false };
+    let delta: DeltaTransform | undefined;
+    switch (this.mode) {
+      case 'translate':
+        delta = this.solver.solveAxisTranslation(this.drag.startWorld, currentWorld, this.drag.hit.axis, this.frame, context);
+        break;
+      case 'rotate':
+        delta = this.solver.solveAxisRotation(this.drag.startWorld, currentWorld, this.drag.hit.axis, this.frame, context);
+        break;
+      case 'scale':
+        delta = this.solver.solveAxisScale(this.drag.startWorld, currentWorld, this.drag.hit.axis, this.frame, context);
+        break;
+    }
+    if (!delta) {
+      return;
+    }
+    this.applyDeltaToTargets(delta, this.drag);
+    this.hud.update(delta);
+    this.scene.requestRender();
+  }
+
+  private onDragEnd(cancelled: boolean): void {
+    if (cancelled && this.drag) {
+      this.drag.baseMatrices.forEach((matrix, target) => {
+        this.writeTargetMatrix(target, matrix);
+      });
+    }
+    this.drag = undefined;
+    this.hud.reset();
+    this.updateFrame();
+  }
+
+  private intersectPointer(position: Cartesian2, hit: GizmoHit, pivot: Cartesian3): Cartesian3 | undefined {
+    const ray = this.camera.getPickRay(position, scratchRay);
+    if (!ray) {
+      return undefined;
+    }
+    if (this.mode === 'translate') {
+      const axisVector = Matrix3.getColumn(this.frame!.axes, axisToIndex(hit.axis), new Cartesian3());
+      const planeNormal = this.createAxisPlaneNormal(axisVector);
+      Plane.fromPointNormal(pivot, planeNormal, scratchPlane);
+      return IntersectionTests.rayPlane(ray, scratchPlane, new Cartesian3());
+    }
+    if (this.mode === 'rotate' || this.mode === 'scale') {
+      const axisVector = Matrix3.getColumn(this.frame!.axes, axisToIndex(hit.axis), new Cartesian3());
+      Plane.fromPointNormal(pivot, axisVector, scratchPlane);
+      return IntersectionTests.rayPlane(ray, scratchPlane, new Cartesian3());
+    }
+    return undefined;
+  }
+
+  private createAxisPlaneNormal(axisVector: Cartesian3): Cartesian3 {
+    const cameraDirection = Cartesian3.normalize(this.camera.direction, new Cartesian3());
+    const cross = Cartesian3.cross(cameraDirection, axisVector, new Cartesian3());
+    if (Cartesian3.magnitudeSquared(cross) < 1e-6) {
+      // Axis parallel to camera direction, fallback to another perpendicular vector
+      const fallback = axisVector.y !== 0 || axisVector.z !== 0 ? new Cartesian3(1, 0, 0) : new Cartesian3(0, 1, 0);
+      Cartesian3.cross(axisVector, fallback, cross);
+    }
+    const planeNormal = Cartesian3.cross(axisVector, cross, new Cartesian3());
+    return Cartesian3.normalize(planeNormal, planeNormal);
+  }
+
+  private applyDeltaToTargets(delta: DeltaTransform, drag: ActiveDragState): void {
+    const pivot = drag.pivot;
+    const deltaMatrix = Matrix4.fromTranslationQuaternionRotationScale(delta.translation, delta.rotation, delta.scale, new Matrix4());
+    drag.baseMatrices.forEach((baseMatrix, target) => {
+      const targetPivot = drag.perTargetPivot?.get(target) ?? pivot;
+      const pivotTranslationLocal = Matrix4.fromTranslation(targetPivot, new Matrix4());
+      const pivotInverseLocal = Matrix4.fromTranslation(Cartesian3.negate(targetPivot, new Cartesian3()), new Matrix4());
+      const deltaAroundTargetPivot = Matrix4.multiply(
+        Matrix4.multiply(pivotTranslationLocal, deltaMatrix, new Matrix4()),
+        pivotInverseLocal,
+        new Matrix4()
+      );
+      const result = Matrix4.multiply(deltaAroundTargetPivot, baseMatrix, new Matrix4());
+      this.writeTargetMatrix(target, result);
+    });
+  }
+
+  private getTargetMatrix(target: ManipulatorTarget): Matrix4 {
+    if ('getMatrix' in target) {
+      return target.getMatrix();
+    }
+    return target.matrix;
+  }
+
+  private writeTargetMatrix(target: ManipulatorTarget, matrix: Matrix4): void {
+    if ('setMatrix' in target) {
+      target.setMatrix(Matrix4.clone(matrix, new Matrix4()));
+    } else {
+      (target as any).matrix = Matrix4.clone(matrix, new Matrix4());
+    }
+  }
+}
+
+function axisToIndex(axis: Axis): number {
+  switch (axis) {
+    case 'x':
+      return 0;
+    case 'y':
+      return 1;
+    case 'z':
+    default:
+      return 2;
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,64 @@
+import type { Cartesian3, Matrix3, Matrix4, Quaternion } from 'cesium';
+
+export type Axis = 'x' | 'y' | 'z';
+export type Mode = 'translate' | 'rotate' | 'scale';
+export type Orientation = 'global' | 'local' | 'view' | 'enu' | 'normal' | 'gimbal';
+export type Pivot = 'origin' | 'median' | 'cursor' | 'individual';
+
+export interface TargetLike {
+  matrix: Matrix4;
+  setMatrix(matrix: Matrix4): void;
+}
+
+export interface TargetEntity {
+  getMatrix(): Matrix4;
+  setMatrix(matrix: Matrix4): void;
+}
+
+export type ManipulatorTarget = TargetLike | TargetEntity;
+
+export interface ManipulatorOptions {
+  target?: ManipulatorTarget | ManipulatorTarget[];
+  orientation?: Orientation;
+  pivot?: Pivot;
+  enableTranslate?: boolean;
+  enableRotate?: boolean;
+  enableScale?: boolean;
+  snap?: SnapOptions;
+  size?: SizeOptions;
+}
+
+export interface SizeOptions {
+  screenPixelRadius?: number;
+  minScale?: number;
+  maxScale?: number;
+}
+
+export interface SnapOptions {
+  translate?: number;
+  rotate?: number;
+  scale?: number;
+}
+
+export interface FrameState {
+  origin: Cartesian3;
+  axes: Matrix3;
+  matrix: Matrix4;
+}
+
+export interface DeltaTransform {
+  translation: Cartesian3;
+  rotation: Quaternion;
+  scale: Cartesian3;
+}
+
+export interface SnapContext {
+  ctrlKey: boolean;
+  shiftKey: boolean;
+}
+
+export interface InteractionEvent {
+  startPosition: Cartesian3;
+  currentPosition: Cartesian3;
+  delta: DeltaTransform;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,10 @@
+export * from './core/types';
+export { UniversalManipulator, type UniversalManipulatorOptions } from './core/UniversalManipulator';
+export { FrameBuilder } from './core/FrameBuilder';
+export { TransformSolver } from './core/TransformSolver';
+export { Snapper } from './core/Snapper';
+export { PivotResolver } from './core/PivotResolver';
+export { HudOverlay } from './core/HudOverlay';
+export { GizmoPrimitive } from './render/GizmoPrimitive';
+export { GizmoPicker } from './interaction/GizmoPicker';
+export { ManipulatorController } from './interaction/ManipulatorController';

--- a/src/interaction/GizmoPicker.ts
+++ b/src/interaction/GizmoPicker.ts
@@ -1,0 +1,57 @@
+import { Cartesian2, Cartesian3, Scene, SceneTransforms, Matrix3 } from 'cesium';
+import type { Axis, FrameState, Mode } from '../core/types';
+
+export interface GizmoHit {
+  mode: Mode;
+  axis: Axis;
+  distance: number;
+}
+
+const MAX_PICK_DISTANCE = 30;
+
+export class GizmoPicker {
+  constructor(private readonly scene: Scene) {}
+
+  public pick(windowPosition: Cartesian2, frame: FrameState, mode: Mode): GizmoHit | undefined {
+    const camera = this.scene.camera;
+    const axisCandidates: Axis[] = ['x', 'y', 'z'];
+    let best: GizmoHit | undefined;
+    axisCandidates.forEach((axis) => {
+      const axisPoint = this.computeAxisEndpoint(frame, axis);
+      const screenOrigin = SceneTransforms.worldToWindowCoordinates(this.scene, frame.origin);
+      const screenEnd = SceneTransforms.worldToWindowCoordinates(this.scene, axisPoint);
+      if (!screenOrigin || !screenEnd) {
+        return;
+      }
+      const distance = distancePointToSegment(windowPosition, screenOrigin, screenEnd);
+      if (distance < MAX_PICK_DISTANCE && (!best || distance < best.distance)) {
+        best = { mode, axis, distance };
+      }
+    });
+    return best;
+  }
+
+  private computeAxisEndpoint(frame: FrameState, axis: Axis): Cartesian3 {
+    const axisIndex = axis === 'x' ? 0 : axis === 'y' ? 1 : 2;
+    const axisVector = Cartesian3.normalize(
+      Matrix3.getColumn(frame.axes, axisIndex, new Cartesian3()),
+      new Cartesian3()
+    );
+    return Cartesian3.add(
+      frame.origin,
+      Cartesian3.multiplyByScalar(axisVector, 5.0, new Cartesian3()),
+      new Cartesian3()
+    );
+  }
+}
+
+function distancePointToSegment(point: Cartesian2, start: Cartesian2, end: Cartesian2): number {
+  const segment = Cartesian2.subtract(end, start, new Cartesian2());
+  const lengthSquared = Cartesian2.dot(segment, segment);
+  if (lengthSquared === 0) {
+    return Cartesian2.distance(point, start);
+  }
+  const t = Math.max(0, Math.min(1, Cartesian2.dot(Cartesian2.subtract(point, start, new Cartesian2()), segment) / lengthSquared));
+  const projection = Cartesian2.add(start, Cartesian2.multiplyByScalar(segment, t, new Cartesian2()), new Cartesian2());
+  return Cartesian2.distance(point, projection);
+}

--- a/src/interaction/ManipulatorController.ts
+++ b/src/interaction/ManipulatorController.ts
@@ -1,0 +1,96 @@
+import {
+  Cartesian2,
+  ScreenSpaceEventHandler,
+  ScreenSpaceEventType,
+  Scene
+} from 'cesium';
+import type { GizmoHit, GizmoPicker } from './GizmoPicker';
+import type { FrameState, Mode } from '../core/types';
+
+export interface ManipulatorControllerCallbacks {
+  onHover(hit: GizmoHit | undefined): void;
+  onDragStart(hit: GizmoHit, position: Cartesian2): void;
+  onDragMove(position: Cartesian2): void;
+  onDragEnd(cancelled: boolean): void;
+}
+
+export class ManipulatorController {
+  private readonly scene: Scene;
+  private readonly picker: GizmoPicker;
+  private readonly callbacks: ManipulatorControllerCallbacks;
+  private readonly handler: ScreenSpaceEventHandler;
+  private mode: Mode = 'translate';
+  private frame: FrameState | undefined;
+  private hover: GizmoHit | undefined;
+  private dragging = false;
+
+  constructor(scene: Scene, picker: GizmoPicker, callbacks: ManipulatorControllerCallbacks) {
+    this.scene = scene;
+    this.picker = picker;
+    this.callbacks = callbacks;
+    this.handler = new ScreenSpaceEventHandler(scene.canvas);
+    this.bindEvents();
+  }
+
+  public setMode(mode: Mode): void {
+    this.mode = mode;
+  }
+
+  public setFrame(frame: FrameState | undefined): void {
+    this.frame = frame;
+  }
+
+  public destroy(): void {
+    this.handler.destroy();
+  }
+
+  private bindEvents(): void {
+    this.handler.setInputAction((movement) => {
+      if (!this.frame) {
+        return;
+      }
+      const position = movement.endPosition ?? movement.startPosition ?? movement.position;
+      if (!position) {
+        return;
+      }
+      const hit = this.picker.pick(position, this.frame, this.mode);
+      this.hover = hit;
+      this.callbacks.onHover(hit);
+    }, ScreenSpaceEventType.MOUSE_MOVE);
+
+    this.handler.setInputAction((movement) => {
+      if (!this.frame || !this.hover) {
+        return;
+      }
+      this.dragging = true;
+      this.callbacks.onDragStart(this.hover, movement.position);
+    }, ScreenSpaceEventType.LEFT_DOWN);
+
+    this.handler.setInputAction((movement) => {
+      if (!this.dragging) {
+        return;
+      }
+      const position = movement.endPosition ?? movement.startPosition ?? movement.position;
+      if (!position) {
+        return;
+      }
+      this.callbacks.onDragMove(position);
+    }, ScreenSpaceEventType.MOUSE_MOVE);
+
+    this.handler.setInputAction(() => {
+      if (!this.dragging) {
+        return;
+      }
+      this.dragging = false;
+      this.callbacks.onDragEnd(false);
+    }, ScreenSpaceEventType.LEFT_UP);
+
+    this.handler.setInputAction(() => {
+      if (!this.dragging) {
+        return;
+      }
+      this.dragging = false;
+      this.callbacks.onDragEnd(true);
+    }, ScreenSpaceEventType.RIGHT_DOWN);
+  }
+}

--- a/src/render/GizmoPrimitive.ts
+++ b/src/render/GizmoPrimitive.ts
@@ -1,0 +1,86 @@
+import { Cartesian3, Color, PolylineCollection, PrimitiveCollection, Scene, Matrix3 } from 'cesium';
+import type { FrameState } from '../core/types';
+
+const AXIS_LENGTH = 1.0;
+
+export interface GizmoPrimitiveOptions {
+  scene: Scene;
+}
+
+interface AxisVisual {
+  axis: 'x' | 'y' | 'z';
+  polyline: ReturnType<PolylineCollection['add']>;
+  color: Color;
+}
+
+export class GizmoPrimitive {
+  private readonly scene: Scene;
+  private readonly collection: PrimitiveCollection;
+  private readonly polylines: PolylineCollection;
+  private readonly axes: AxisVisual[];
+  private frame: FrameState | undefined;
+  private show = true;
+
+  constructor(options: GizmoPrimitiveOptions) {
+    this.scene = options.scene;
+    this.collection = new PrimitiveCollection();
+    this.polylines = new PolylineCollection();
+    this.axes = [];
+    this.collection.add(this.polylines);
+    this.scene.primitives.add(this.collection);
+    this.createAxes();
+  }
+
+  public setShow(show: boolean): void {
+    this.show = show;
+    this.collection.show = show;
+  }
+
+  public update(frame: FrameState, scale: number): void {
+    this.frame = frame;
+    const origin = frame.origin;
+    this.axes.forEach((axisInfo) => {
+      const axisVector = Matrix3.getColumn(frame.axes, axisIndex(axisInfo.axis), new Cartesian3());
+      const endPoint = Cartesian3.add(
+        origin,
+        Cartesian3.multiplyByScalar(Cartesian3.normalize(axisVector, axisVector), AXIS_LENGTH * scale, new Cartesian3()),
+        new Cartesian3()
+      );
+      axisInfo.polyline.positions = [Cartesian3.clone(origin, new Cartesian3()), endPoint];
+      axisInfo.polyline.width = 4;
+      axisInfo.polyline.material = axisInfo.color;
+    });
+  }
+
+  public destroy(): void {
+    this.scene.primitives.remove(this.collection);
+  }
+
+  private createAxes(): void {
+    const definitions: Array<{ axis: 'x' | 'y' | 'z'; color: Color }> = [
+      { axis: 'x', color: Color.RED },
+      { axis: 'y', color: Color.LIME },
+      { axis: 'z', color: Color.BLUE }
+    ];
+    definitions.forEach((def) => {
+      const polyline = this.polylines.add({
+        positions: [Cartesian3.ZERO, Cartesian3.UNIT_X],
+        width: 4,
+        material: def.color
+      });
+      this.axes.push({ axis: def.axis, polyline, color: def.color });
+    });
+  }
+}
+
+function axisIndex(axis: 'x' | 'y' | 'z'): number {
+  switch (axis) {
+    case 'x':
+      return 0;
+    case 'y':
+      return 1;
+    case 'z':
+    default:
+      return 2;
+  }
+}

--- a/src/utils/cesium.ts
+++ b/src/utils/cesium.ts
@@ -1,0 +1,54 @@
+import {
+  Cartesian3,
+  Cartographic,
+  Matrix3,
+  Matrix4,
+  Quaternion,
+  Transforms
+} from 'cesium';
+
+export function computeEnuFrame(position: Cartesian3, result = new Matrix4()): Matrix4 {
+  return Transforms.eastNorthUpToFixedFrame(position, undefined, result);
+}
+
+export function computeEnuAxes(position: Cartesian3): Matrix3 {
+  const matrix = computeEnuFrame(position);
+  const axes = Matrix3.fromMatrix4(matrix);
+  return axes;
+}
+
+export function cartesianArrayMedian(points: Cartesian3[]): Cartesian3 {
+  if (points.length === 0) {
+    return new Cartesian3();
+  }
+  const cartographic = points.map((point) => Cartographic.fromCartesian(point));
+  cartographic.sort((a, b) => a.longitude - b.longitude);
+  const medianLongitude = cartographic[Math.floor(cartographic.length / 2)].longitude;
+  cartographic.sort((a, b) => a.latitude - b.latitude);
+  const medianLatitude = cartographic[Math.floor(cartographic.length / 2)].latitude;
+  cartographic.sort((a, b) => a.height - b.height);
+  const medianHeight = cartographic[Math.floor(cartographic.length / 2)].height;
+  return Cartesian3.fromRadians(medianLongitude, medianLatitude, medianHeight);
+}
+
+export function normalizeQuaternion(quaternion: Quaternion): Quaternion {
+  return Quaternion.normalize(quaternion, quaternion);
+}
+
+export function quaternionToMatrix(quaternion: Quaternion): Matrix3 {
+  return Matrix3.fromQuaternion(quaternion);
+}
+
+export function matrixToQuaternion(matrix: Matrix3): Quaternion {
+  return Quaternion.fromRotationMatrix(matrix);
+}
+
+export function ensureQuaternionContinuous(previous: Quaternion, current: Quaternion): Quaternion {
+  if (Quaternion.dot(previous, current) < 0) {
+    current.x *= -1;
+    current.y *= -1;
+    current.z *= -1;
+    current.w *= -1;
+  }
+  return current;
+}

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,133 @@
+import {
+  Cartesian2,
+  Cartesian3,
+  Matrix3,
+  Matrix4,
+  Quaternion
+} from 'cesium';
+
+export interface TRS {
+  translation: Cartesian3;
+  rotation: Quaternion;
+  scale: Cartesian3;
+}
+
+export const EPSILON = 1e-8;
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180.0;
+}
+
+export function toDegrees(radians: number): number {
+  return (radians * 180.0) / Math.PI;
+}
+
+export function createIdentityTRS(): TRS {
+  return {
+    translation: new Cartesian3(),
+    rotation: Quaternion.IDENTITY.clone(),
+    scale: new Cartesian3(1, 1, 1)
+  };
+}
+
+export function composeMatrix(trs: TRS, result = new Matrix4()): Matrix4 {
+  return Matrix4.fromTranslationQuaternionRotationScale(
+    trs.translation,
+    trs.rotation,
+    trs.scale,
+    result
+  );
+}
+
+export function decomposeMatrix(matrix: Matrix4): TRS {
+  const translation = new Cartesian3();
+  const rotation = new Quaternion();
+  const scale = new Cartesian3();
+  Matrix4.decompose(matrix, translation, rotation, scale);
+  return { translation, rotation, scale };
+}
+
+export function projectVectorOnAxis(vector: Cartesian3, axis: Cartesian3): number {
+  const axisNormalized = Cartesian3.normalize(axis, new Cartesian3());
+  return Cartesian3.dot(vector, axisNormalized);
+}
+
+export function rejectVectorFromAxis(vector: Cartesian3, axis: Cartesian3, result = new Cartesian3()): Cartesian3 {
+  const axisNormalized = Cartesian3.normalize(axis, new Cartesian3());
+  const projection = Cartesian3.multiplyByScalar(axisNormalized, Cartesian3.dot(vector, axisNormalized), new Cartesian3());
+  return Cartesian3.subtract(vector, projection, result);
+}
+
+export function axisAngleToQuaternion(axis: Cartesian3, angle: number, result = new Quaternion()): Quaternion {
+  const halfAngle = angle * 0.5;
+  const s = Math.sin(halfAngle);
+  const c = Math.cos(halfAngle);
+  const n = Cartesian3.normalize(axis, new Cartesian3());
+  result.x = n.x * s;
+  result.y = n.y * s;
+  result.z = n.z * s;
+  result.w = c;
+  return result;
+}
+
+export function quaternionMultiply(a: Quaternion, b: Quaternion, result = new Quaternion()): Quaternion {
+  return Quaternion.multiply(a, b, result);
+}
+
+export function quaternionFromVectors(from: Cartesian3, to: Cartesian3, result = new Quaternion()): Quaternion {
+  const normalizedFrom = Cartesian3.normalize(from, new Cartesian3());
+  const normalizedTo = Cartesian3.normalize(to, new Cartesian3());
+  const dot = Cartesian3.dot(normalizedFrom, normalizedTo);
+  if (dot > 1 - EPSILON) {
+    return Quaternion.clone(Quaternion.IDENTITY, result);
+  }
+  if (dot < -1 + EPSILON) {
+    const axis = findOrthogonal(normalizedFrom);
+    return axisAngleToQuaternion(axis, Math.PI, result);
+  }
+  const axis = Cartesian3.cross(normalizedFrom, normalizedTo, new Cartesian3());
+  const angle = Math.acos(clamp(dot, -1, 1));
+  return axisAngleToQuaternion(axis, angle, result);
+}
+
+export function findOrthogonal(vector: Cartesian3): Cartesian3 {
+  if (Math.abs(vector.x) < Math.abs(vector.y)) {
+    return Math.abs(vector.x) < Math.abs(vector.z)
+      ? new Cartesian3(0, -vector.z, vector.y)
+      : new Cartesian3(-vector.y, vector.x, 0);
+  }
+  return Math.abs(vector.y) < Math.abs(vector.z)
+    ? new Cartesian3(vector.z, 0, -vector.x)
+    : new Cartesian3(-vector.y, vector.x, 0);
+}
+
+export function orthonormalize(matrix: Matrix3, result = new Matrix3()): Matrix3 {
+  const column0 = Matrix3.getColumn(matrix, 0, new Cartesian3());
+  const column1 = Matrix3.getColumn(matrix, 1, new Cartesian3());
+  const column2 = Matrix3.getColumn(matrix, 2, new Cartesian3());
+
+  Cartesian3.normalize(column0, column0);
+  Cartesian3.normalize(column1, column1);
+  Cartesian3.normalize(column2, column2);
+
+  Matrix3.setColumn(result, 0, column0, result);
+  Matrix3.setColumn(result, 1, column1, result);
+  Matrix3.setColumn(result, 2, column2, result);
+  return result;
+}
+
+export function screenDeltaToNdc(delta: Cartesian2, canvasSize: Cartesian2): Cartesian2 {
+  return new Cartesian2((delta.x * 2) / canvasSize.x, (-delta.y * 2) / canvasSize.y);
+}
+
+export function almostEquals(a: number, b: number, epsilon = 1e-5): boolean {
+  return Math.abs(a - b) <= epsilon;
+}
+
+export function almostEqualsVector(a: Cartesian3, b: Cartesian3, epsilon = 1e-5): boolean {
+  return almostEquals(a.x, b.x, epsilon) && almostEquals(a.y, b.y, epsilon) && almostEquals(a.z, b.z, epsilon);
+}

--- a/tests/transformSolver.test.ts
+++ b/tests/transformSolver.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { TransformSolver } from '../src/core/TransformSolver';
+import { Snapper } from '../src/core/Snapper';
+import { PivotResolver } from '../src/core/PivotResolver';
+import { FrameBuilder } from '../src/core/FrameBuilder';
+import type { FrameState, ManipulatorTarget } from '../src/core/types';
+import { Cartesian3, Matrix3, Matrix4, Math as CesiumMath } from 'cesium';
+
+function createIdentityFrame(origin = new Cartesian3()): FrameState {
+  return {
+    origin,
+    axes: Matrix3.IDENTITY.clone(),
+    matrix: Matrix4.fromTranslation(origin, new Matrix4())
+  };
+}
+
+describe('TransformSolver', () => {
+  const snapper = new Snapper({});
+  const solver = new TransformSolver(snapper);
+  const frame = createIdentityFrame(new Cartesian3(0, 0, 0));
+  const context = { ctrlKey: false, shiftKey: false };
+
+  it('solves axis translation along X', () => {
+    const start = new Cartesian3(0, 0, 0);
+    const current = new Cartesian3(10, 0, 0);
+    const delta = solver.solveAxisTranslation(start, current, 'x', frame, context);
+    expect(delta.translation.x).toBeCloseTo(10);
+    expect(delta.translation.y).toBeCloseTo(0);
+    expect(delta.translation.z).toBeCloseTo(0);
+  });
+
+  it('solves plane translation in XY', () => {
+    const start = new Cartesian3(0, 0, 0);
+    const current = new Cartesian3(5, 7, 0);
+    const delta = solver.solvePlaneTranslation(start, current, 'x', 'y', frame, context);
+    expect(delta.translation.x).toBeCloseTo(5);
+    expect(delta.translation.y).toBeCloseTo(7);
+    expect(delta.translation.z).toBeCloseTo(0);
+  });
+
+  it('solves rotation around Z axis', () => {
+    const start = new Cartesian3(1, 0, 0);
+    const current = new Cartesian3(0, 1, 0);
+    const delta = solver.solveAxisRotation(start, current, 'z', frame, context);
+    const angle = 2 * Math.acos(delta.rotation.w);
+    expect(CesiumMath.toDegrees(angle)).toBeCloseTo(90, 5);
+  });
+
+  it('solves scale along Y axis', () => {
+    const start = new Cartesian3(0, 1, 0);
+    const current = new Cartesian3(0, 3, 0);
+    const delta = solver.solveAxisScale(start, current, 'y', frame, context);
+    expect(delta.scale.y).toBeCloseTo(3);
+  });
+});
+
+describe('PivotResolver', () => {
+  const resolver = new PivotResolver();
+  const targetA: ManipulatorTarget = {
+    matrix: Matrix4.fromTranslation(new Cartesian3(0, 0, 0)),
+    setMatrix() {}
+  };
+  const targetB: ManipulatorTarget = {
+    matrix: Matrix4.fromTranslation(new Cartesian3(10, 0, 0)),
+    setMatrix() {}
+  };
+
+  it('returns origin pivot for origin mode', () => {
+    const result = resolver.resolve([targetA, targetB], 'origin');
+    expect(result.pivotPoint.x).toBeCloseTo(0);
+  });
+
+  it('returns median pivot', () => {
+    const result = resolver.resolve([targetA, targetB], 'median');
+    expect(result.pivotPoint.x).toBeCloseTo(5);
+  });
+});
+
+describe('FrameBuilder', () => {
+  const builder = new FrameBuilder();
+  const origin = new Cartesian3(1, 2, 3);
+  const matrix = Matrix4.fromRotationTranslation(Matrix3.IDENTITY, origin, new Matrix4());
+
+  it('builds global frame', () => {
+    const frame = builder.build(origin, matrix, 'global');
+    expect(frame.origin.x).toBeCloseTo(origin.x);
+    expect(frame.origin.y).toBeCloseTo(origin.y);
+    expect(frame.origin.z).toBeCloseTo(origin.z);
+    expect(frame.axes.equalsEpsilon(Matrix3.IDENTITY, 1e-5)).toBe(true);
+  });
+
+  it('builds local frame', () => {
+    const rotation = Matrix3.fromRotationZ(CesiumMath.toRadians(45));
+    const localMatrix = Matrix4.fromRotationTranslation(rotation, origin, new Matrix4());
+    const frame = builder.build(origin, localMatrix, 'local');
+    expect(frame.axes.equalsEpsilon(rotation, 1e-5)).toBe(true);
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "removeComments": false,
+    "sourceMap": true
+  },
+  "exclude": ["tests", "examples", "vite.config.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals", "cesium"]
+  },
+  "include": ["src", "examples", "tests"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  build: {
+    sourcemap: true,
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'CesiumUniversalManipulator',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index${format === 'es' ? '' : '.cjs'}`
+    },
+    rollupOptions: {
+      external: ['cesium'],
+      output: {
+        globals: {
+          cesium: 'Cesium'
+        }
+      }
+    }
+  },
+  server: {
+    port: 4173
+  }
+});


### PR DESCRIPTION
## Summary
- implement modular universal manipulator core with snapping, frame building, pivot resolving, and solver utilities
- add Cesium scene gizmo primitives, HUD overlay, and interaction controller tied together by `UniversalManipulator`
- provide Vite-powered example application and Vitest coverage for solver, frame, and pivot logic

## Testing
- npm run test *(fails: vitest is unavailable because npm install is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c85d1bec832dbce323bb8b837b66